### PR TITLE
Fix AbstractInstance to AbstractOptimizer

### DIFF
--- a/src/LinQuadOptInterface.jl
+++ b/src/LinQuadOptInterface.jl
@@ -95,7 +95,7 @@ macro def(name, definition)
 end
 
 # Abstract + macro
-abstract type LinQuadSolverInstance <: MOI.AbstractSolverInstance end
+abstract type LinQuadSolverInstance <: MOI.AbstractOptimizer end
 @def LinQuadSolverInstanceBase begin
     inner::Model
 


### PR DESCRIPTION
The interface was creating an issue #3  because MathOptInterface changed AbstractSolverInstance to AbstractOptimizer 