### PR TITLE
WIP: tidy

### DIFF
--- a/src/LinQuadOptInterface.jl
+++ b/src/LinQuadOptInterface.jl
@@ -1,3 +1,10 @@
+#=
+ TODOs:
+
+    - get quadratic objective functions
+
+=#
+
 __precompile__()
 module LinQuadOptInterface
 
@@ -180,7 +187,7 @@ function MOI.isempty(m::LinQuadOptimizer)
     ret = true
     ret = ret && m.name == ""
     ret = ret && m.obj_is_quad == false
-    ret = ret && m.obj_sense == MOI.FeasibilitySense
+    ret = ret && m.obj_sense == MOI.MinSense
     ret = ret && m.last_variable_reference == 0
     ret = ret && isempty(m.variable_mapping)
     ret = ret && isempty(m.variable_names)
@@ -212,7 +219,8 @@ function MOI.empty!(m::M, env = nothing) where M<:LinQuadOptimizer
     m.inner = LinQuadModel(M,env)
 
     m.obj_is_quad = false
-    m.obj_sense = MOI.FeasibilitySense
+    # we assume the default is minimization
+    m.obj_sense = MOI.MinSense
 
     m.last_variable_reference = 0
     m.variable_mapping = Dict{MathOptInterface.VariableIndex, Int}()

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -1,64 +1,40 @@
-function MOI.canaddconstraint(m::LinQuadOptimizer, f::Type{F}, s::Type{S}) where {F<:MOI.AbstractFunction, S<:MOI.AbstractSet}
-    return (f,s) in lqs_supported_constraints(m)
-end
-
 #=
     Helper functions to store constraint mappings
 =#
 cmap(m::LinQuadOptimizer) = m.constraint_mapping
-
-function Base.getindex(m::LinQuadOptimizer, c::CI{F,S}) where F where S
-    dict = constrdict(m, c)
-    return dict[c]
-end
-constrdict(m::LinQuadOptimizer, ::LCI{LE})  = cmap(m).less_than
-constrdict(m::LinQuadOptimizer, ::LCI{GE})  = cmap(m).greater_than
-constrdict(m::LinQuadOptimizer, ::LCI{EQ})  = cmap(m).equal_to
-constrdict(m::LinQuadOptimizer, ::LCI{IV})  = cmap(m).interval
-
-constrdict(m::LinQuadOptimizer, ::VLCI{MOI.Nonnegatives})  = cmap(m).nonnegatives
-constrdict(m::LinQuadOptimizer, ::VLCI{MOI.Nonpositives}) = cmap(m).nonpositives
-constrdict(m::LinQuadOptimizer, ::VLCI{MOI.Zeros})         = cmap(m).zeros
-
-constrdict(m::LinQuadOptimizer, ::QCI{LE})  = cmap(m).q_less_than
-constrdict(m::LinQuadOptimizer, ::QCI{GE})  = cmap(m).q_greater_than
-constrdict(m::LinQuadOptimizer, ::QCI{EQ})  = cmap(m).q_equal_to
-
-constrdict(m::LinQuadOptimizer, ::SVCI{LE}) = cmap(m).upper_bound
-constrdict(m::LinQuadOptimizer, ::SVCI{GE}) = cmap(m).lower_bound
-constrdict(m::LinQuadOptimizer, ::SVCI{EQ}) = cmap(m).fixed_bound
-constrdict(m::LinQuadOptimizer, ::SVCI{IV}) = cmap(m).interval_bound
-
-constrdict(m::LinQuadOptimizer, ::VVCI{MOI.Nonnegatives}) = cmap(m).vv_nonnegatives
-constrdict(m::LinQuadOptimizer, ::VVCI{MOI.Nonpositives}) = cmap(m).vv_nonpositives
-constrdict(m::LinQuadOptimizer, ::VVCI{MOI.Zeros}) = cmap(m).vv_zeros
-
-constrdict(m::LinQuadOptimizer, ::SVCI{MOI.ZeroOne}) = cmap(m).binary
-constrdict(m::LinQuadOptimizer, ::SVCI{MOI.Integer}) = cmap(m).integer
-
-constrdict(m::LinQuadOptimizer, ::VVCI{SOS1}) = cmap(m).sos1
-constrdict(m::LinQuadOptimizer, ::VVCI{SOS2}) = cmap(m).sos2
-
+# dummy method for isvalid
 constrdict(m::LinQuadOptimizer, ref) = false
 
 _getrhs(set::LE) = set.upper
 _getrhs(set::GE) = set.lower
 _getrhs(set::EQ) = set.value
 
-_getsense(m::LinQuadOptimizer, ::EQ) = Cchar('E')
-_getsense(m::LinQuadOptimizer, ::LE) = Cchar('L')
-_getsense(m::LinQuadOptimizer, ::GE) = Cchar('G')
-_getsense(m::LinQuadOptimizer, ::MOI.Zeros)        = Cchar('E')
-_getsense(m::LinQuadOptimizer, ::MOI.Nonpositives) = Cchar('L')
-_getsense(m::LinQuadOptimizer, ::MOI.Nonnegatives) = Cchar('G')
-_getboundsense(m::LinQuadOptimizer, ::MOI.Nonpositives) = Cchar('U')
-_getboundsense(m::LinQuadOptimizer, ::MOI.Nonnegatives) = Cchar('L')
+function Base.getindex(m::LinQuadOptimizer, c::CI{F,S}) where F where S
+    dict = constrdict(m, c)
+    return dict[c]
+end
 
+function deleteconstraintname!(m::LinQuadOptimizer, ref)
+    if haskey(m.constraint_names, ref)
+        name = m.constraint_names[ref]
+        delete!(m.constraint_names_rev, name)
+        delete!(m.constraint_names, ref)
+    end
+end
 
-_variableub(m::LinQuadOptimizer) = Cchar('U')
-_variablelb(m::LinQuadOptimizer) = Cchar('L')
+"""
+    hasinteger(m::LinQuadOptimizer)::Bool
 
-MOI.isvalid(m::LinQuadOptimizer, ref) = false
+A helper function to determine if the solver instance `m` has any integer
+components (i.e. binary, integer, special ordered sets, etc).
+"""
+function hasinteger(m::LinQuadOptimizer)
+    length(cmap(m).integer) + length(cmap(m).binary) + length(cmap(m).sos1) + length(cmap(m).sos2) > 0
+end
+
+#=
+    MOI.isvalid
+=#
 
 function MOI.isvalid(m::LinQuadOptimizer, ref::CI{F,S}) where F where S
     dict = constrdict(m, ref)
@@ -72,31 +48,40 @@ function MOI.isvalid(m::LinQuadOptimizer, ref::CI{F,S}) where F where S
 end
 
 #=
+    canaddconstraint
+=#
+
+function MOI.canaddconstraint(m::LinQuadOptimizer, f::Type{F}, s::Type{S}) where {F<:MOI.AbstractFunction, S<:MOI.AbstractSet}
+    return (f,s) in lqs_supported_constraints(m)
+end
+
+#=
     Get number of constraints
 =#
 
-function MOI.get(m::LinQuadOptimizer, ::MOI.NumberOfConstraints{F, S}) where F where S
-    length(constrdict(m, CI{F,S}(UInt(0))))
-end
 function MOI.canget(m::LinQuadOptimizer, ::MOI.NumberOfConstraints{F, S}) where F where S
     return (F,S) in lqs_supported_constraints(m)
+end
+function MOI.get(m::LinQuadOptimizer, ::MOI.NumberOfConstraints{F, S}) where F where S
+    length(constrdict(m, CI{F,S}(UInt(0))))
 end
 
 #=
     Get list of constraint references
 =#
 
-function MOI.get(m::LinQuadOptimizer, ::MOI.ListOfConstraintIndices{F, S}) where F where S
-    sort(collect(keys(constrdict(m, CI{F,S}(UInt(0))))), by=x->x.value)
-end
 function MOI.canget(m::LinQuadOptimizer, ::MOI.ListOfConstraintIndices{F, S}) where F where S
     return (F,S) in lqs_supported_constraints(m)
+end
+function MOI.get(m::LinQuadOptimizer, ::MOI.ListOfConstraintIndices{F, S}) where F where S
+    sort(collect(keys(constrdict(m, CI{F,S}(UInt(0))))), by=x->x.value)
 end
 
 #=
     Get list of constraint types in model
 =#
 
+MOI.canget(m::LinQuadOptimizer, ::MOI.ListOfConstraints) = true
 function MOI.get(m::LinQuadOptimizer, ::MOI.ListOfConstraints)
     ret = []
     for (F,S) in lqs_supported_constraints(m)
@@ -106,31 +91,12 @@ function MOI.get(m::LinQuadOptimizer, ::MOI.ListOfConstraints)
     end
     ret
 end
-MOI.canget(m::LinQuadOptimizer, ::MOI.ListOfConstraints) = true
 
 #=
-    Set variable bounds
+    Get constraint names
 =#
 
-function setvariablebound!(m::LinQuadOptimizer, col::Int, bound::Float64, sense::Cchar)
-    lqs_chgbds!(m, [col], [bound], [sense])
-end
-
-function setvariablebound!(m::LinQuadOptimizer, v::SinVar, set::LE)
-    setvariablebound!(m, getcol(m, v), set.upper, _variableub(m))
-end
-function setvariablebound!(m::LinQuadOptimizer, v::SinVar, set::GE)
-    setvariablebound!(m, getcol(m, v), set.lower, _variablelb(m))
-end
-function setvariablebound!(m::LinQuadOptimizer, v::SinVar, set::EQ)
-    setvariablebound!(m, getcol(m, v), set.value, _variableub(m))
-    setvariablebound!(m, getcol(m, v), set.value, _variablelb(m))
-end
-function setvariablebound!(m::LinQuadOptimizer, v::SinVar, set::IV)
-    setvariablebound!(m, getcol(m, v), set.upper, _variableub(m))
-    setvariablebound!(m, getcol(m, v), set.lower, _variablelb(m))
-end
-
+MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintName, ::Type{<:MOI.ConstraintIndex}) = true
 function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintName, c::MOI.ConstraintIndex)
     if haskey(m.constraint_names, c)
         m.constraint_names[c]
@@ -138,7 +104,12 @@ function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintName, c::MOI.ConstraintInd
         ""
     end
 end
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintName, ::Type{<:MOI.ConstraintIndex}) = true
+
+#=
+    Set constraint names
+=#
+
+MOI.canset(m::LinQuadOptimizer, ::MOI.ConstraintName, ::Type{<:MOI.ConstraintIndex}) = true
 function MOI.set!(m::LinQuadOptimizer, ::MOI.ConstraintName, ref::MOI.ConstraintIndex, name::String)
     if haskey(m.constraint_names_rev, name)
         if m.constraint_names_rev[name] != ref
@@ -154,659 +125,37 @@ function MOI.set!(m::LinQuadOptimizer, ::MOI.ConstraintName, ref::MOI.Constraint
         m.constraint_names_rev[name] = ref
     end
 end
-MOI.canset(m::LinQuadOptimizer, ::MOI.ConstraintName, ::Type{<:MOI.ConstraintIndex}) = true
 
-function deleteconstraintname!(m::LinQuadOptimizer, ref)
-    if haskey(m.constraint_names, ref)
-        name = m.constraint_names[ref]
-        delete!(m.constraint_names_rev, name)
-        delete!(m.constraint_names, ref)
-    end
-end
+#=
+    Get constraint by name
+=#
 
+# this covers the non-type-stable get(m, ConstraintIndex) case
+MOI.canget(m::LinQuadOptimizer, ::Type{MOI.ConstraintIndex}, name::String) = haskey(m.constraint_names_rev, name)
 function MOI.get(m::LinQuadOptimizer, ::Type{<:MOI.ConstraintIndex}, name::String)
     m.constraint_names_rev[name]
 end
-MOI.canget(m::LinQuadOptimizer, ::Type{MOI.ConstraintIndex}, name::String) = haskey(m.constraint_names_rev, name)
 
+# this covers the type-stable get(m, ConstraintIndex{F,S}, name)::CI{F,S} case
 function MOI.canget(m::LinQuadOptimizer, ::Type{FS}, name::String) where FS <: MOI.ConstraintIndex
     haskey(m.constraint_names_rev, name) && typeof(m.constraint_names_rev[name]) == FS
 end
-
-function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::S) where S <: LinSets
-    setvariablebound!(m, v, set)
-    m.last_constraint_reference += 1
-    ref = SVCI{S}(m.last_constraint_reference)
-    dict = constrdict(m, ref)
-    dict[ref] = v.variable
-    ref
+function MOI.get(m::LinQuadOptimizer, ::Type{MOI.ConstraintIndex{F,S}}, name::String) where F where S
+    m.constraint_names_rev[name]::MOI.ConstraintIndex{F,S}
 end
 
 #=
-    Get constraint set of variable bound
+    Below we add constraints.
+
+    - addconstraint!
+    - delete!
+    - get(m, ConstraintSet(), c)
+    - get(m, ConstraintFunction(), c)
+    - modifyconstraint!
 =#
 
-getbound(m::LinQuadOptimizer, c::SVCI{LE}) = lqs_getub(m, getcol(m, m[c]))
-getbound(m::LinQuadOptimizer, c::SVCI{GE}) = lqs_getlb(m, getcol(m, m[c]))
-getbound(m::LinQuadOptimizer, c::SVCI{EQ}) = lqs_getlb(m, getcol(m, m[c]))
-
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{S}) where S <: Union{LE, GE, EQ}
-    S(getbound(m, c))
-end
-
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{IV})
-    col = getcol(m, m[c])
-    lb = lqs_getlb(m, col)
-    ub = lqs_getub(m, col)
-    return Interval{Float64}(lb, ub)
-end
-
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::SVCI{S}) where S <: LinSets = true
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{<:SVCI{S}}) where S <: LinSets = true
-
-#=
-    Get constraint function of variable bound
-=#
-
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{<: LinSets})
-    return SinVar(m[c])
-end
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{<: LinSets}) = true
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{<:SVCI{<: LinSets}}) = true
-
-#=
-    Change variable bounds of same set
-=#
-
-function MOI.modifyconstraint!(m::LinQuadOptimizer, c::SVCI{S}, newset::S) where S <: LinSets
-    setvariablebound!(m, SinVar(m[c]), newset)
-end
-MOI.canmodifyconstraint(::LinQuadOptimizer, ::SVCI{S}, ::Type{S}) where S <: LinSets = true
-
-#=
-    Delete a variable bound
-=#
-
-function MOI.delete!(m::LinQuadOptimizer, c::SVCI{S}) where S <: LinSets
-    deleteconstraintname!(m, c)
-    dict = constrdict(m, c)
-    vref = dict[c]
-    setvariablebound!(m, SinVar(vref), IV(-Inf, Inf))
-    delete!(dict, c)
-end
-MOI.candelete(m::LinQuadOptimizer, c::SVCI{S}) where S <: LinSets = true
-
-#=
-    Vector valued bounds
-=#
-# function setvariablebounds!(m::LinQuadOptimizer, func::VecVar, set::S)  where S <: Union{MOI.Nonnegatives, MOI.Nonpositives}
-#     n = MOI.dimension(set)
-#     lqs_chgbds!(m, getcol.(m, func.variables), fill(0.0, n), fill(_getboundsense(m,set), n))
-# end
-# function setvariablebounds!(m::LinQuadOptimizer, func::VecVar, set::MOI.Zeros)
-#     n = MOI.dimension(set)
-#     lqs_chgbds!(m, getcol.(m, func.variables), fill(0.0, n), fill(_variablelb(m), n))
-#     lqs_chgbds!(m, getcol.(m, func.variables), fill(0.0, n), fill(_variableub(m), n))
-# end
-
-function MOI.addconstraint!(m::LinQuadOptimizer, func::VecVar, set::S) where S <: VecLinSets
-    @assert length(func.variables) == MOI.dimension(set)
-    # setvariablebounds!(m, func, set)
-    m.last_constraint_reference += 1
-    ref = VVCI{S}(m.last_constraint_reference)
-
-    rows = lqs_getnumrows(m)
-
-    n = MOI.dimension(set)
-    lqs_addrows!(m, collect(1:n), getcol.(m, func.variables), ones(n), fill(_getsense(m,set),n), zeros(n))
-
-    dict = constrdict(m, ref)
-
-    dict[ref] = collect(rows+1:rows+n)
-
-    append!(m.constraint_primal_solution, fill(NaN,n))
-    append!(m.constraint_dual_solution, fill(NaN,n))
-    append!(m.constraint_constant, fill(0.0,n))
-    return ref
-end
-
-
-#=
-    Get constraint set of vector variable bound
-=#
-
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::VVCI{S}) where S <: VecLinSets
-    S(length(m[c]))
-end
-
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::VVCI{S}) where S <: VecLinSets = true
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{<:VVCI{S}}) where S <: VecLinSets = true
-
-#=
-    Get constraint function of vector variable bound (linear ctr)
-=#
-
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::VVCI{<: VecLinSets})
-    refs = m[c]
-    out = VarInd[]
-    sizehint!(out, length(refs))
-    for ref in refs
-        colidx, coefs = lqs_getrows(m, ref)
-        if length(colidx) != 1
-            error("Unexpected constraint")
-        end
-        push!(out,m.variable_references[colidx[1]+1])
-    end
-    return VecVar(out)
-end
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::VVCI{<: VecLinSets}) = true
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{<:VVCI{<: VecLinSets}}) = true
-
-#=
-    Delete a vector variable bound
-=#
-
-# TODO
-
-#=
-    Add linear constraints
-=#
-
-
-function MOI.addconstraint!(m::LinQuadOptimizer, func::Linear, set::T) where T <: LinSets
-    cfunc = MOIU.canonical(func)
-    unsafe_addconstraint!(m, cfunc, set)
-end
-function unsafe_addconstraint!(m::LinQuadOptimizer, func::Linear, set::T) where T <: LinSets
-    addlinearconstraint!(m, func, set)
-    m.last_constraint_reference += 1
-    ref = LCI{T}(m.last_constraint_reference)
-
-    dict = constrdict(m, ref)
-    dict[ref] = lqs_getnumrows(m)
-    push!(m.constraint_primal_solution, NaN)
-    push!(m.constraint_dual_solution, NaN)
-    push!(m.constraint_constant, func.constant)
-    return ref
-end
-
-function addlinearconstraint!(m::LinQuadOptimizer, func::Linear, set::S) where S <: Union{LE, GE, EQ}
-    addlinearconstraint!(m, func, _getsense(m,set), _getrhs(set))
-end
-
-function addlinearconstraint!(m::LinQuadOptimizer, func::Linear, set::IV)
-    addlinearconstraint!(m, func, lqs_ctrtype_map(m)[:RANGE], set.lower)
-    lqs_chgrngval!(m, [lqs_getnumrows(m)], [set.upper - set.lower])
-end
-
-function addlinearconstraint!(m::LinQuadOptimizer, func::Linear, sense::Cchar, rhs)
-    if abs(func.constant) > eps(Float64)
-        warn("Constant in scalar function moved into set.")
-    end
-    lqs_addrows!(m, [1], getcol.(m, func.variables), func.coefficients, [sense], [rhs - func.constant])
-end
-
-#=
-    Add linear constraints (plural)
-=#
-
-function MOI.addconstraints!(m::LinQuadOptimizer, func::Vector{Linear}, set::Vector{S}) where S <: LinSets
-    cfunc = MOIU.canonical.(func)
-    unsafe_addconstraints!(m, cfunc, set)
-end
-function unsafe_addconstraints!(m::LinQuadOptimizer, func::Vector{Linear}, set::Vector{S}) where S <: LinSets
-    @assert length(func) == length(set)
-    numrows = lqs_getnumrows(m)
-    addlinearconstraints!(m, func, set)
-    crefs = Vector{LCI{S}}(length(func))
-    for i in 1:length(func)
-        m.last_constraint_reference += 1
-        ref = LCI{S}(m.last_constraint_reference)
-        dict = constrdict(m, ref)
-        dict[ref] = numrows + i
-        push!(m.constraint_primal_solution, NaN)
-        push!(m.constraint_dual_solution, NaN)
-        push!(m.constraint_constant, func[i].constant)
-        crefs[i] = ref
-    end
-    return crefs
-end
-
-function addlinearconstraints!(m::LinQuadOptimizer, func::Vector{Linear}, set::Vector{S}) where S <: LinSets
-    addlinearconstraints!(m, func, fill(_getsense(m,set[1]), length(func)), [_getrhs(s) for s in set])
-end
-
-function addlinearconstraints!(m::LinQuadOptimizer, func::Vector{Linear}, set::Vector{IV})
-    numrows = lqs_getnumrows(m)
-    addlinearconstraints!(m, func, fill(lqs_ctrtype_map(m)[:RANGE], length(func)), [s.lower for s in set])
-    numrows2 = lqs_getnumrows(m)
-    lqs_chgrngval!(m, collect(numrows+1:numrows2), [s.upper - s.lower for s in set])
-end
-
-function addlinearconstraints!(m::LinQuadOptimizer, func::Vector{Linear}, sense::Vector{Cchar}, rhs::Vector{Float64})
-    # loop through once to get number of non-zeros and to move rhs across
-    nnz = 0
-    for (i, f) in enumerate(func)
-        if abs(f.constant) > eps(Float64)
-            warn("Constant in scalar function moved into set.")
-            rhs[i] -= f.constant
-        end
-        nnz += length(f.coefficients)
-    end
-
-    rowbegins = Vector{Int}(length(func))   # index of start of each row
-    column_indices = Vector{Int}(nnz)       # flattened columns for each function
-    nnz_vals = Vector{Float64}(nnz)         # corresponding non-zeros
-    cnt = 1
-    for (fi, f) in enumerate(func)
-        rowbegins[fi] = cnt
-        for (var, coef) in zip(f.variables, f.coefficients)
-            column_indices[cnt] = getcol(m, var)
-            nnz_vals[cnt] = coef
-            cnt += 1
-        end
-    end
-    lqs_addrows!(m, rowbegins, column_indices, nnz_vals, sense, rhs)
-end
-
-#=
-    Constraint set of Linear function
-=#
-
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::LCI{S}) where S <: Union{LE, GE, EQ}
-    rhs = lqs_getrhs(m, m[c])
-    S(rhs+m.constraint_constant[m[c]])
-end
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::LCI{<: Union{LE, GE, EQ}}) = true
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{<:LCI{<: Union{LE, GE, EQ}}}) = true
-
-#=
-    Constraint function of Linear function
-=#
-
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::LCI{<: LinSets})
-    # TODO more efficiently
-    colidx, coefs = lqs_getrows(m, m[c])
-    Linear(m.variable_references[colidx+1], coefs, -m.constraint_constant[m[c]])
-end
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::LCI{<: LinSets}) = true
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{<:LCI{<: LinSets}}) = true
-
-#=
-    Scalar Coefficient Change of Linear Constraint
-=#
-
-function MOI.modifyconstraint!(m::LinQuadOptimizer, c::LCI{<: LinSets}, chg::MOI.ScalarCoefficientChange{Float64})
-    col = m.variable_mapping[chg.variable]
-    lqs_chgcoef!(m, m[c], col, chg.new_coefficient)
-end
-MOI.canmodifyconstraint(m::LinQuadOptimizer, c::LCI{<: LinSets}, ::Type{MOI.ScalarCoefficientChange{Float64}}) = true
-
-#=
-    Change RHS of linear constraint without modifying sense
-=#
-
-function MOI.modifyconstraint!(m::LinQuadOptimizer, c::LCI{S}, newset::S) where S <: Union{LE, GE, EQ}
-    # the column 0 (or -1 in 0-index) is the rhs.
-    lqs_chgcoef!(m, m[c], 0, _getrhs(newset))
-end
-MOI.canmodifyconstraint(m::LinQuadOptimizer, c::LCI{S}, ::Type{S}) where S <: Union{LE, GE, EQ} = true
-
-function MOI.modifyconstraint!(m::LinQuadOptimizer, c::LCI{IV}, set::IV)
-    # the column 0 (or -1 in 0-index) is the rhs.
-    # a range constraint has the RHS value of the lower limit of the range, and
-    # a rngval equal to upper-lower.
-    row = m[c]
-    lqs_chgcoef!(m, row, 0, set.lower)
-    lqs_chgrngval!(m, [row], [set.upper - set.lower])
-end
-MOI.canmodifyconstraint(m::LinQuadOptimizer, c::LCI{IV}, ::Type{IV}) = true
-
-#=
-    Delete a linear constraint
-=#
-
-function deleteref!(m::LinQuadOptimizer, row::Int, ref::LCI{<: LinSets})
-    deleteref!(cmap(m).less_than, row, ref)
-    deleteref!(cmap(m).greater_than, row, ref)
-    deleteref!(cmap(m).equal_to, row, ref)
-    deleteref!(cmap(m).interval, row, ref)
-end
-function MOI.delete!(m::LinQuadOptimizer, c::LCI{<: LinSets})
-    deleteconstraintname!(m, c)
-    dict = constrdict(m, c)
-    row = dict[c]
-    lqs_delrows!(m, row, row)
-    deleteat!(m.constraint_primal_solution, row)
-    deleteat!(m.constraint_dual_solution, row)
-    deleteat!(m.constraint_constant, row)
-    deleteref!(m, row, c)
-end
-MOI.candelete(m::LinQuadOptimizer, c::LCI{<: LinSets}) = true
-
-#=
-    MIP related constraints
-=#
-"""
-    hasinteger(m::LinQuadOptimizer)::Bool
-A helper function to determine if the solver instance `m` has any integer
-components (i.e. binary, integer, special ordered sets, etc).
-"""
-function hasinteger(m::LinQuadOptimizer)
-    length(cmap(m).integer) + length(cmap(m).binary) + length(cmap(m).sos1) + length(cmap(m).sos2) > 0
-end
-
-#=
-    Binary constraints
- for some reason CPLEX doesn't respect bounds on a binary variable, so we
- should store the previous bounds so that if we delete the binary constraint
- we can revert to the old bounds
-
- Xpress is worse, once binary the bounds are changed independly of what the user does
-=#
-function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, ::MOI.ZeroOne)
-    m.last_constraint_reference += 1
-    ref = SVCI{MOI.ZeroOne}(m.last_constraint_reference)
-    dict = constrdict(m, ref)
-    ub = lqs_getub(m, getcol(m, v))
-    lb = lqs_getlb(m, getcol(m, v))
-    dict[ref] = (v.variable, lb, ub)
-    lqs_chgctype!(m, [getcol(m, v)], [lqs_vartype_map(m)[:BINARY]])
-    setvariablebound!(m, getcol(m, v), 1.0, _variableub(m))
-    setvariablebound!(m, getcol(m, v), 0.0, _variablelb(m))
-    lqs_make_problem_type_integer(m)
-    ref
-end
-function MOI.delete!(m::LinQuadOptimizer, c::SVCI{MOI.ZeroOne})
-    deleteconstraintname!(m, c)
-    dict = constrdict(m, c)
-    (v, lb, ub) = dict[c]
-    lqs_chgctype!(m, [getcol(m, v)], [lqs_vartype_map(m)[:CONTINUOUS]])
-    setvariablebound!(m, getcol(m, v), ub, _variableub(m))
-    setvariablebound!(m, getcol(m, v), lb, _variablelb(m))
-    delete!(dict, c)
-    if !hasinteger(m)
-        lqs_make_problem_type_continuous(m)
-    end
-end
-MOI.candelete(m::LinQuadOptimizer, c::SVCI{MOI.ZeroOne}) = true
-
-MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{MOI.ZeroOne}) =MOI.ZeroOne()
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{MOI.ZeroOne}) = true
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{<:SVCI{MOI.ZeroOne}}) = true
-
-MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{MOI.ZeroOne}) = m[c]
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{MOI.ZeroOne}) = true
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{<:SVCI{MOI.ZeroOne}}) = true
-
-
-#=
-    Integer constraints
-=#
-
-function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, ::MOI.Integer)
-    lqs_chgctype!(m, [getcol(m, v)], [lqs_vartype_map(m)[:INTEGER]])
-    m.last_constraint_reference += 1
-    ref = SVCI{MOI.Integer}(m.last_constraint_reference)
-    dict = constrdict(m, ref)
-    dict[ref] = v.variable
-    lqs_make_problem_type_integer(m)
-    ref
-end
-
-function MOI.delete!(m::LinQuadOptimizer, c::SVCI{MOI.Integer})
-    deleteconstraintname!(m, c)
-    dict = constrdict(m, c)
-    v = dict[c]
-    lqs_chgctype!(m, [getcol(m, v)], [lqs_vartype_map(m)[:CONTINUOUS]])
-    delete!(dict, c)
-    if !hasinteger(m)
-        lqs_make_problem_type_continuous(m)
-    end
-end
-MOI.candelete(m::LinQuadOptimizer, c::SVCI{MOI.Integer}) = true
-
-MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{MOI.Integer}) =MOI.Integer()
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{MOI.Integer}) = true
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{<:SVCI{MOI.Integer}}) = true
-
-MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{MOI.Integer}) = m[c]
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{MOI.Integer}) = true
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{<:SVCI{MOI.Integer}}) = true
-
-
-#=
-    SOS constraints
-=#
-
-function MOI.addconstraint!(m::LinQuadOptimizer, v::VecVar, sos::SOS1)
-    lqs_make_problem_type_integer(m)
-    lqs_addsos!(m, getcol.(m, v.variables), sos.weights, lqs_sertype_map(m)[:SOS1])
-    m.last_constraint_reference += 1
-    ref = VVCI{SOS1}(m.last_constraint_reference)
-    dict = constrdict(m, ref)
-    dict[ref] = length(cmap(m).sos1) + length(cmap(m).sos2) + 1
-    ref
-end
-
-function MOI.addconstraint!(m::LinQuadOptimizer, v::VecVar, sos::SOS2)
-    lqs_make_problem_type_integer(m)
-    lqs_addsos!(m, getcol.(m, v.variables), sos.weights, lqs_sertype_map(m)[:SOS2])
-    m.last_constraint_reference += 1
-    ref = VVCI{SOS2}(m.last_constraint_reference)
-    dict = constrdict(m, ref)
-    dict[ref] = length(cmap(m).sos1) + length(cmap(m).sos2) + 1
-    ref
-end
-
-function MOI.delete!(m::LinQuadOptimizer, c::VVCI{<:Union{SOS1, SOS2}})
-    deleteconstraintname!(m, c)
-    dict = constrdict(m, c)
-    idx = dict[c]
-    lqs_delsos!(m, idx, idx)
-    deleteref!(cmap(m).sos1, idx, c)
-    deleteref!(cmap(m).sos2, idx, c)
-    if !hasinteger(m)
-        lqs_make_problem_type_continuous(m)
-    end
-end
-MOI.candelete(m::LinQuadOptimizer, c::VVCI{<:Union{SOS1, SOS2}}) = true
-
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::VVCI{SOS1})
-    indices, weights, types = lqs_getsos(m, m[c])
-    @assert types == lqs_sertype_map(m)[:SOS1]
-    return SOS1(weights)
-end
-
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::VVCI{SOS2})
-    indices, weights, types = lqs_getsos(m, m[c])
-    @assert types == lqs_sertype_map(m)[:SOS2]
-    return SOS2(weights)
-end
-
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::VVCI{<:Union{SOS1, SOS2}}) = true
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{<:VVCI{<:Union{SOS1, SOS2}}}) = true
-
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::VVCI{<:Union{SOS1, SOS2}})
-    indices, weights, types = lqs_getsos(m, m[c])
-    return VecVar(m.variable_references[indices])
-end
-
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::VVCI{<:Union{SOS1, SOS2}}) = true
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{<:VVCI{<:Union{SOS1, SOS2}}}) = true
-
-
-#=
-    Quadratic constraint
-=#
-
-function MOI.addconstraint!(m::LinQuadOptimizer, func::Quad, set::S) where S <: Union{LE, GE, EQ}
-    addquadraticconstraint!(m, func, set)
-    m.last_constraint_reference += 1
-    ref = QCI{S}(m.last_constraint_reference)
-    dict = constrdict(m, ref)
-    push!(m.qconstraint_primal_solution, NaN)
-    push!(m.qconstraint_dual_solution, NaN)
-    # dict[ref] = lqs_getnumqconstrs(m)
-    dict[ref] = length(m.qconstraint_primal_solution)
-    return ref
-end
-
-function addquadraticconstraint!(m::LinQuadOptimizer, func::Quad, set::S) where S<: Union{LE, GE, EQ}
-    addquadraticconstraint!(m, func, _getsense(m,set), _getrhs(set))
-end
-
-function addquadraticconstraint!(m::LinQuadOptimizer, f::Quad, sense::Cchar, rhs::Float64)
-    if abs(f.constant) > 0
-        warn("Constant in quadratic function. Moving into set")
-    end
-    ri, ci, vi = reduceduplicates(
-        getcol.(m, f.quadratic_rowvariables),
-        getcol.(m, f.quadratic_colvariables),
-        f.quadratic_coefficients
-    )
-    lqs_addqconstr!(m,
-        getcol.(m, f.affine_variables),
-        f.affine_coefficients,
-        rhs - f.constant,
-        sense,
-        ri, ci, vi
-    )
-end
-
-function reduceduplicates(rowi::Vector{T}, coli::Vector{T}, vals::Vector{S}) where T where S
-    @assert length(rowi) == length(coli) == length(vals)
-    d = Dict{Tuple{T, T},S}()
-    for (r,c,v) in zip(rowi, coli, vals)
-        if haskey(d, (r,c))
-            d[(r,c)] += v
-        else
-            d[(r,c)] = v
-        end
-    end
-    ri = Vector{T}(length(d))
-    ci = Vector{T}(length(d))
-    vi = Vector{S}(length(d))
-    for (i, (key, val)) in enumerate(d)
-        ri[i] = key[1]
-        ci[i] = key[2]
-        vi[i] = val
-    end
-    ri, ci, vi
-end
-
-#=
-    Vector valued constraints
-=#
-
-function MOI.addconstraint!(m::LinQuadOptimizer, func::VecLin, set::S) where S <: VecLinSets
-    @assert MOI.dimension(set) == length(func.constant)
-
-    nrows = lqs_getnumrows(m)
-    addlinearconstraint!(m, func, _getsense(m,set))
-    nrows2 = lqs_getnumrows(m)
-
-    m.last_constraint_reference += 1
-    ref = VLCI{S}(m.last_constraint_reference)
-
-    dict = constrdict(m, ref)
-    dict[ref] = collect(nrows+1:nrows2)
-    for i in 1:MOI.dimension(set)
-        push!(m.constraint_primal_solution, NaN)
-        push!(m.constraint_dual_solution, NaN)
-        push!(m.constraint_constant, func.constant[i])
-    end
-    ref
-end
-
-function addlinearconstraint!(m::LinQuadOptimizer, func::VecLin, sense::Cchar)
-    @assert length(func.outputindex) == length(func.variables) == length(func.coefficients)
-    # get list of unique rows
-    rows = unique(func.outputindex)
-    @assert length(rows) == length(func.constant)
-    # sort into row order
-    pidx = sortperm(func.outputindex)
-    cols = getcol.(m, func.variables)[pidx]
-    vals = func.coefficients[pidx]
-    # loop through to gte starting position of each row
-    rowbegins = Vector{Int}(length(rows))
-    rowbegins[1] = 1
-    cnt = 1
-    for i in 2:length(pidx)
-        if func.outputindex[pidx[i]] != func.outputindex[pidx[i-1]]
-            cnt += 1
-            rowbegins[cnt] = i
-        end
-    end
-    lqs_addrows!(m, rowbegins, cols, vals, fill(sense, length(rows)), -func.constant)
-end
-
-function MOI.modifyconstraint!(m::LinQuadOptimizer, ref::VLCI{<: VecLinSets}, chg::MOI.VectorConstantChange{Float64})
-    @assert length(chg.new_constant) == length(m[ref])
-    for (r, v) in zip(m[ref], chg.new_constant)
-        lqs_chgcoef!(m, r, 0, -v)
-        m.constraint_constant[r] = v
-    end
-end
-MOI.canmodifyconstraint(m::LinQuadOptimizer, ::VLCI{<: VecLinSets}, ::Type{MOI.VectorConstantChange{Float64}}) = true
-
-#=
-    Constraint set of Linear function
-=#
-
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::VLCI{S}) where S <: VecLinSets
-    ctrs = m[c]
-    n = length(ctrs)
-    S(n)
-end
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::VLCI{<: VecLinSets}) = true
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{<:VLCI{<: VecLinSets}}) = true
-
-#=
-    Constraint function of Linear function
-=#
-
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::VLCI{<: VecLinSets})
-    ctrs = m[c]
-    n = length(ctrs)
-    out = MOI.VectorAffineFunction(Int[],VarInd[],Float64[],Float64[])
-    for i in 1:n
-        rhs = lqs_getrhs(m, ctrs[i])
-        push!(out.constant, -rhs)
-
-        # TODO more efficiently
-        colidx, coefs = lqs_getrows(m, ctrs[i])
-        append!(out.variables, m.variable_references[colidx+1])
-        append!(out.coefficients, coefs)
-        append!(out.outputindex, i*ones(Int,length(coefs)))
-    end
-    return out
-end
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::VLCI{<: VecLinSets}) = true
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{<:VLCI{<: VecLinSets}}) = true
-
-#=
-    Transform scalar constraint
-=#
-
-function MOI.transformconstraint!(m::LinQuadOptimizer, ref::LCI{S}, newset::S) where S
-    error("Cannot transform constraint of same set. use `modifyconstraint!` instead.")
-end
-function MOI.transformconstraint!(m::LinQuadOptimizer, ref::LCI{S1}, newset::S2) where S1 where S2 <: Union{LE, GE, EQ}
-    dict = constrdict(m, ref)
-    row = dict[ref]
-    lqs_chgsense!(m, [row], [_getsense(m,newset)])
-    m.last_constraint_reference += 1
-    ref2 = LCI{S2}(m.last_constraint_reference)
-    dict2 = constrdict(m, ref2)
-    dict2[ref2] = row
-    delete!(dict, ref)
-    deleteconstraintname!(m, ref)
-    return ref2
-end
-function MOI.cantransformconstraint(m::LinQuadOptimizer, ref::LCI{S}, newset::S) where S
-    false
-end
-function MOI.cantransformconstraint(m::LinQuadOptimizer, ref::LCI{S1}, newset::S2) where S1 where S2 <: Union{LE, GE, EQ}
-    true
-end
+include("constraints/singlevariable.jl")
+include("constraints/vectorofvariables.jl")
+include("constraints/scalaraffine.jl")
+include("constraints/vectoraffine.jl")
+include("constraints/scalarquadratic.jl")

--- a/src/constraints/scalaraffine.jl
+++ b/src/constraints/scalaraffine.jl
@@ -1,0 +1,200 @@
+#=
+        ScalarAffineFunction -in- LessThan
+        ScalarAffineFunction -in- GreaterThan
+        ScalarAffineFunction -in- EqualTo
+        ScalarAffineFunction -in- Interval
+=#
+constrdict(m::LinQuadOptimizer, ::LCI{LE})  = cmap(m).less_than
+constrdict(m::LinQuadOptimizer, ::LCI{GE})  = cmap(m).greater_than
+constrdict(m::LinQuadOptimizer, ::LCI{EQ})  = cmap(m).equal_to
+constrdict(m::LinQuadOptimizer, ::LCI{IV})  = cmap(m).interval
+
+function MOI.addconstraint!(m::LinQuadOptimizer, func::Linear, set::T) where T <: LinSets
+    cfunc = MOIU.canonical(func)
+    addlinearconstraint!(m, cfunc, set)
+    m.last_constraint_reference += 1
+    ref = LCI{T}(m.last_constraint_reference)
+    dict = constrdict(m, ref)
+    dict[ref] = lqs_getnumrows(m)
+    push!(m.constraint_primal_solution, NaN)
+    push!(m.constraint_dual_solution, NaN)
+    push!(m.constraint_constant, func.constant)
+    return ref
+end
+
+function addlinearconstraint!(m::LinQuadOptimizer, func::Linear, set::S) where S <: Union{LE, GE, EQ}
+    addlinearconstraint!(m, func, lqs_char(m,set), _getrhs(set))
+end
+
+function addlinearconstraint!(m::LinQuadOptimizer, func::Linear, set::IV)
+    addlinearconstraint!(m, func, lqs_char(m,set), set.lower)
+    lqs_chgrngval!(m, [lqs_getnumrows(m)], [set.upper - set.lower])
+end
+
+function addlinearconstraint!(m::LinQuadOptimizer, func::Linear, sense::Cchar, rhs)
+    if abs(func.constant) > eps(Float64)
+        warn("Constant in scalar function moved into set.")
+    end
+    lqs_addrows!(m, [1], getcol.(m, func.variables), func.coefficients, [sense], [rhs - func.constant])
+end
+
+#=
+    Add linear constraints (plural)
+=#
+
+function MOI.addconstraints!(m::LinQuadOptimizer, func::Vector{Linear}, set::Vector{S}) where S <: LinSets
+    # canonicalize
+    cfunc = MOIU.canonical.(func)
+
+    @assert length(cfunc) == length(set)
+    numrows = lqs_getnumrows(m)
+    addlinearconstraints!(m, cfunc, set)
+    crefs = Vector{LCI{S}}(length(cfunc))
+    for i in 1:length(cfunc)
+        m.last_constraint_reference += 1
+        ref = LCI{S}(m.last_constraint_reference)
+        dict = constrdict(m, ref)
+        dict[ref] = numrows + i
+        push!(m.constraint_primal_solution, NaN)
+        push!(m.constraint_dual_solution, NaN)
+        push!(m.constraint_constant, cfunc[i].constant)
+        crefs[i] = ref
+    end
+    return crefs
+end
+
+function addlinearconstraints!(m::LinQuadOptimizer, func::Vector{Linear}, set::Vector{S}) where S <: LinSets
+    addlinearconstraints!(m, func, lqs_char.(m,set), [_getrhs(s) for s in set])
+end
+
+function addlinearconstraints!(m::LinQuadOptimizer, func::Vector{Linear}, set::Vector{IV})
+    numrows = lqs_getnumrows(m)
+    addlinearconstraints!(m, func, lqs_char.(m,set), [s.lower for s in set])
+    numrows2 = lqs_getnumrows(m)
+    lqs_chgrngval!(m, collect(numrows+1:numrows2), [s.upper - s.lower for s in set])
+end
+
+function addlinearconstraints!(m::LinQuadOptimizer, func::Vector{Linear}, sense::Vector{Cchar}, rhs::Vector{Float64})
+    # loop through once to get number of non-zeros and to move rhs across
+    nnz = 0
+    for (i, f) in enumerate(func)
+        if abs(f.constant) > eps(Float64)
+            warn("Constant in scalar function moved into set.")
+            rhs[i] -= f.constant
+        end
+        nnz += length(f.coefficients)
+    end
+    rowbegins = Vector{Int}(length(func))   # index of start of each row
+    column_indices = Vector{Int}(nnz)       # flattened columns for each function
+    nnz_vals = Vector{Float64}(nnz)         # corresponding non-zeros
+    cnt = 1
+    for (fi, f) in enumerate(func)
+        rowbegins[fi] = cnt
+        for (var, coef) in zip(f.variables, f.coefficients)
+            column_indices[cnt] = getcol(m, var)
+            nnz_vals[cnt] = coef
+            cnt += 1
+        end
+    end
+    lqs_addrows!(m, rowbegins, column_indices, nnz_vals, sense, rhs)
+end
+
+#=
+    Constraint set of Linear function
+=#
+
+MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{LCI{S}}) where S <: Union{LE, GE, EQ} = true
+function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::LCI{S}) where S <: Union{LE, GE, EQ}
+    rhs = lqs_getrhs(m, m[c])
+    S(rhs+m.constraint_constant[m[c]])
+end
+
+#=
+    Constraint function of Linear function
+=#
+
+MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{<:LCI{<: LinSets}}) = true
+function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::LCI{<: LinSets})
+    # TODO more efficiently
+    colidx, coefs = lqs_getrows(m, m[c])
+    Linear(m.variable_references[colidx+1], coefs, -m.constraint_constant[m[c]])
+end
+
+#=
+    Scalar Coefficient Change of Linear Constraint
+=#
+
+MOI.canmodifyconstraint(m::LinQuadOptimizer, c::LCI{<: LinSets}, ::Type{MOI.ScalarCoefficientChange{Float64}}) = true
+function MOI.modifyconstraint!(m::LinQuadOptimizer, c::LCI{<: LinSets}, chg::MOI.ScalarCoefficientChange{Float64})
+    col = m.variable_mapping[chg.variable]
+    lqs_chgcoef!(m, m[c], col, chg.new_coefficient)
+end
+
+#=
+    Change RHS of linear constraint without modifying sense
+=#
+
+MOI.canmodifyconstraint(m::LinQuadOptimizer, c::LCI{S}, ::Type{S}) where S <: Union{LE, GE, EQ} = true
+function MOI.modifyconstraint!(m::LinQuadOptimizer, c::LCI{S}, newset::S) where S <: Union{LE, GE, EQ}
+    # the column 0 (or -1 in 0-index) is the rhs.
+    lqs_chgcoef!(m, m[c], 0, _getrhs(newset))
+end
+
+MOI.canmodifyconstraint(m::LinQuadOptimizer, c::LCI{IV}, ::Type{IV}) = true
+function MOI.modifyconstraint!(m::LinQuadOptimizer, c::LCI{IV}, set::IV)
+    # the column 0 (or -1 in 0-index) is the rhs.
+    # a range constraint has the RHS value of the lower limit of the range, and
+    # a rngval equal to upper-lower.
+    row = m[c]
+    lqs_chgcoef!(m, row, 0, set.lower)
+    lqs_chgrngval!(m, [row], [set.upper - set.lower])
+end
+
+#=
+    Delete a linear constraint
+=#
+
+MOI.candelete(m::LinQuadOptimizer, c::LCI{<: LinSets}) = true
+function MOI.delete!(m::LinQuadOptimizer, c::LCI{<: LinSets})
+    deleteconstraintname!(m, c)
+    dict = constrdict(m, c)
+    row = dict[c]
+    lqs_delrows!(m, row, row)
+    deleteat!(m.constraint_primal_solution, row)
+    deleteat!(m.constraint_dual_solution, row)
+    deleteat!(m.constraint_constant, row)
+    deleteref!(m, row, c)
+end
+function deleteref!(m::LinQuadOptimizer, row::Int, ref::LCI{<: LinSets})
+    deleteref!(cmap(m).less_than, row, ref)
+    deleteref!(cmap(m).greater_than, row, ref)
+    deleteref!(cmap(m).equal_to, row, ref)
+    deleteref!(cmap(m).interval, row, ref)
+end
+
+#=
+    Transform scalar constraint
+=#
+
+function MOI.cantransformconstraint(m::LinQuadOptimizer, ref::LCI{S}, newset::S) where S
+    false
+end
+function MOI.transformconstraint!(m::LinQuadOptimizer, ref::LCI{S}, newset::S) where S
+    error("Cannot transform constraint of same set. use `modifyconstraint!` instead.")
+end
+
+function MOI.cantransformconstraint(m::LinQuadOptimizer, ref::LCI{S1}, newset::S2) where S1 where S2 <: Union{LE, GE, EQ}
+    true
+end
+function MOI.transformconstraint!(m::LinQuadOptimizer, ref::LCI{S1}, newset::S2) where S1 where S2 <: Union{LE, GE, EQ}
+    dict = constrdict(m, ref)
+    row = dict[ref]
+    lqs_chgsense!(m, [row], [lqs_char(m,newset)])
+    m.last_constraint_reference += 1
+    ref2 = LCI{S2}(m.last_constraint_reference)
+    dict2 = constrdict(m, ref2)
+    dict2[ref2] = row
+    delete!(dict, ref)
+    deleteconstraintname!(m, ref)
+    return ref2
+end

--- a/src/constraints/scalarquadratic.jl
+++ b/src/constraints/scalarquadratic.jl
@@ -1,0 +1,68 @@
+#=
+        ScalarQuadraticFunction -in- LessThan
+        ScalarQuadraticFunction -in- GreaterThan
+        ScalarQuadraticFunction -in- EqualTo
+
+    TODO:
+        - constraint sets
+        - constraint functions
+        - deleting constraints
+=#
+constrdict(m::LinQuadOptimizer, ::QCI{LE})  = cmap(m).q_less_than
+constrdict(m::LinQuadOptimizer, ::QCI{GE})  = cmap(m).q_greater_than
+constrdict(m::LinQuadOptimizer, ::QCI{EQ})  = cmap(m).q_equal_to
+
+function MOI.addconstraint!(m::LinQuadOptimizer, func::Quad, set::S) where S <: Union{LE, GE, EQ}
+    addquadraticconstraint!(m, func, set)
+    m.last_constraint_reference += 1
+    ref = QCI{S}(m.last_constraint_reference)
+    dict = constrdict(m, ref)
+    push!(m.qconstraint_primal_solution, NaN)
+    push!(m.qconstraint_dual_solution, NaN)
+    # dict[ref] = lqs_getnumqconstrs(m)
+    dict[ref] = length(m.qconstraint_primal_solution)
+    return ref
+end
+
+function addquadraticconstraint!(m::LinQuadOptimizer, func::Quad, set::S) where S<: Union{LE, GE, EQ}
+    addquadraticconstraint!(m, func, lqs_char(m,set), _getrhs(set))
+end
+
+function addquadraticconstraint!(m::LinQuadOptimizer, f::Quad, sense::Cchar, rhs::Float64)
+    if abs(f.constant) > 0
+        warn("Constant in quadratic function. Moving into set")
+    end
+    ri, ci, vi = reduceduplicates(
+        getcol.(m, f.quadratic_rowvariables),
+        getcol.(m, f.quadratic_colvariables),
+        f.quadratic_coefficients
+    )
+    lqs_addqconstr!(m,
+        getcol.(m, f.affine_variables),
+        f.affine_coefficients,
+        rhs - f.constant,
+        sense,
+        ri, ci, vi
+    )
+end
+
+function reduceduplicates(rowi::Vector{T}, coli::Vector{T}, vals::Vector{S}) where T where S
+    @assert length(rowi) == length(coli) == length(vals)
+    d = Dict{Tuple{T, T},S}()
+    for (r,c,v) in zip(rowi, coli, vals)
+        if haskey(d, (r,c))
+            d[(r,c)] += v
+        else
+            d[(r,c)] = v
+        end
+    end
+    ri = Vector{T}(length(d))
+    ci = Vector{T}(length(d))
+    vi = Vector{S}(length(d))
+    for (i, (key, val)) in enumerate(d)
+        ri[i] = key[1]
+        ci[i] = key[2]
+        vi[i] = val
+    end
+    ri, ci, vi
+end

--- a/src/constraints/singlevariable.jl
+++ b/src/constraints/singlevariable.jl
@@ -1,0 +1,163 @@
+#=
+    Variable bounds
+        SingleVariable -in- LessThan
+        SingleVariable -in- GreaterThan
+        SingleVariable -in- EqualTo
+        SingleVariable -in- Interval
+
+TODO
+
+    Binary
+        SingleVariable -in- ZeroOne
+        SingleVariable -in- Integer
+=#
+constrdict(m::LinQuadOptimizer, ::SVCI{LE}) = cmap(m).upper_bound
+constrdict(m::LinQuadOptimizer, ::SVCI{GE}) = cmap(m).lower_bound
+constrdict(m::LinQuadOptimizer, ::SVCI{EQ}) = cmap(m).fixed_bound
+constrdict(m::LinQuadOptimizer, ::SVCI{IV}) = cmap(m).interval_bound
+
+constrdict(m::LinQuadOptimizer, ::SVCI{MOI.ZeroOne}) = cmap(m).binary
+constrdict(m::LinQuadOptimizer, ::SVCI{MOI.Integer}) = cmap(m).integer
+
+function setvariablebound!(m::LinQuadOptimizer, col::Int, bound::Float64, sense::Cchar)
+    lqs_chgbds!(m, [col], [bound], [sense])
+end
+
+function setvariablebound!(m::LinQuadOptimizer, v::SinVar, set::LE)
+    setvariablebound!(m, getcol(m, v), set.upper, lqs_char(m, Val{:Upperbound}()))
+end
+function setvariablebound!(m::LinQuadOptimizer, v::SinVar, set::GE)
+    setvariablebound!(m, getcol(m, v), set.lower, lqs_char(m, Val{:Lowerbound}()))
+end
+function setvariablebound!(m::LinQuadOptimizer, v::SinVar, set::EQ)
+    setvariablebound!(m, getcol(m, v), set.value, lqs_char(m, Val{:Upperbound}()))
+    setvariablebound!(m, getcol(m, v), set.value, lqs_char(m, Val{:Lowerbound}()))
+end
+function setvariablebound!(m::LinQuadOptimizer, v::SinVar, set::IV)
+    setvariablebound!(m, getcol(m, v), set.upper, lqs_char(m, Val{:Upperbound}()))
+    setvariablebound!(m, getcol(m, v), set.lower, lqs_char(m, Val{:Lowerbound}()))
+end
+
+# add constraint
+function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::S) where S <: LinSets
+    setvariablebound!(m, v, set)
+    m.last_constraint_reference += 1
+    ref = SVCI{S}(m.last_constraint_reference)
+    dict = constrdict(m, ref)
+    dict[ref] = v.variable
+    ref
+end
+
+# delete constraint
+MOI.candelete(m::LinQuadOptimizer, c::SVCI{S}) where S <: LinSets = true
+function MOI.delete!(m::LinQuadOptimizer, c::SVCI{S}) where S <: LinSets
+    deleteconstraintname!(m, c)
+    dict = constrdict(m, c)
+    vref = dict[c]
+    setvariablebound!(m, SinVar(vref), IV(-Inf, Inf))
+    delete!(dict, c)
+end
+
+# constraint set
+MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{SVCI{S}}) where S <: LinSets = true
+function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{LE})
+    MOI.LessThan{Float64}(lqs_getub(m, getcol(m, m[c])))
+end
+function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{GE})
+    MOI.GreaterThan{Float64}(lqs_getlb(m, getcol(m, m[c])))
+end
+function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{EQ})
+    MOI.EqualTo{Float64}(lqs_getlb(m, getcol(m, m[c])))
+end
+function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{IV})
+    lb = lqs_getlb(m, getcol(m, m[c]))
+    ub = lqs_getub(m, getcol(m, m[c]))
+    return MOI.Interval{Float64}(lb, ub)
+end
+
+# constraint function
+MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{SVCI{S}}) where S <: LinSets = true
+function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{<: LinSets})
+    return SinVar(m[c])
+end
+
+# modify
+MOI.canmodifyconstraint(::LinQuadOptimizer, ::SVCI{S}, ::Type{S}) where S <: LinSets = true
+function MOI.modifyconstraint!(m::LinQuadOptimizer, c::SVCI{S}, newset::S) where S <: LinSets
+    setvariablebound!(m, SinVar(m[c]), newset)
+end
+
+#=
+    Binary constraints
+
+For some reason CPLEX doesn't respect bounds on a binary variable, so we
+should store the previous bounds so that if we delete the binary constraint
+we can revert to the old bounds
+
+Xpress is worse, once binary, the bounds are changed independently of what the user does
+=#
+function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::MOI.ZeroOne)
+    m.last_constraint_reference += 1
+    ref = SVCI{MOI.ZeroOne}(m.last_constraint_reference)
+    dict = constrdict(m, ref)
+    ub = lqs_getub(m, getcol(m, v))
+    lb = lqs_getlb(m, getcol(m, v))
+    dict[ref] = (v.variable, lb, ub)
+    lqs_chgctype!(m, [getcol(m, v)], [lqs_char(m, set)])
+    setvariablebound!(m, getcol(m, v), 1.0, lqs_char(m, Val{:Upperbound}()))
+    setvariablebound!(m, getcol(m, v), 0.0, lqs_char(m, Val{:Lowerbound}()))
+    lqs_make_problem_type_integer(m)
+    ref
+end
+
+MOI.candelete(m::LinQuadOptimizer, c::SVCI{MOI.ZeroOne}) = true
+function MOI.delete!(m::LinQuadOptimizer, c::SVCI{MOI.ZeroOne})
+    deleteconstraintname!(m, c)
+    dict = constrdict(m, c)
+    (v, lb, ub) = dict[c]
+    lqs_chgctype!(m, [getcol(m, v)], [lqs_char(m, Val{:Continuous}())])
+    setvariablebound!(m, getcol(m, v), ub, lqs_char(m, Val{:Upperbound}()))
+    setvariablebound!(m, getcol(m, v), lb, lqs_char(m, Val{:Lowerbound}()))
+    delete!(dict, c)
+    if !hasinteger(m)
+        lqs_make_problem_type_continuous(m)
+    end
+end
+
+MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{SVCI{MOI.ZeroOne}}) = true
+MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{MOI.ZeroOne}) = MOI.ZeroOne()
+
+MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{SVCI{MOI.ZeroOne}}) = true
+MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{MOI.ZeroOne}) = m[c]
+
+#=
+    Integer constraints
+=#
+
+function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::MOI.Integer)
+    lqs_chgctype!(m, [getcol(m, v)], [lqs_char(m, set)])
+    m.last_constraint_reference += 1
+    ref = SVCI{MOI.Integer}(m.last_constraint_reference)
+    dict = constrdict(m, ref)
+    dict[ref] = v.variable
+    lqs_make_problem_type_integer(m)
+    ref
+end
+
+function MOI.delete!(m::LinQuadOptimizer, c::SVCI{MOI.Integer})
+    deleteconstraintname!(m, c)
+    dict = constrdict(m, c)
+    v = dict[c]
+    lqs_chgctype!(m, [getcol(m, v)], [lqs_char(m, Val{:Continuous}())])
+    delete!(dict, c)
+    if !hasinteger(m)
+        lqs_make_problem_type_continuous(m)
+    end
+end
+MOI.candelete(m::LinQuadOptimizer, c::SVCI{MOI.Integer}) = true
+
+MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{SVCI{MOI.Integer}}) = true
+MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{MOI.Integer}) = MOI.Integer()
+
+MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{MOI.Integer}) = m[c]
+MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{SVCI{MOI.Integer}}) = true

--- a/src/constraints/vectoraffine.jl
+++ b/src/constraints/vectoraffine.jl
@@ -1,0 +1,89 @@
+#=
+    Vector valued constraints
+=#
+constrdict(m::LinQuadOptimizer, ::VLCI{MOI.Nonnegatives}) = cmap(m).nonnegatives
+constrdict(m::LinQuadOptimizer, ::VLCI{MOI.Nonpositives}) = cmap(m).nonpositives
+constrdict(m::LinQuadOptimizer, ::VLCI{MOI.Zeros})        = cmap(m).zeros
+
+function MOI.addconstraint!(m::LinQuadOptimizer, func::VecLin, set::S) where S <: VecLinSets
+    @assert MOI.dimension(set) == length(func.constant)
+
+    nrows = lqs_getnumrows(m)
+    addlinearconstraint!(m, func, lqs_char(m,set))
+    nrows2 = lqs_getnumrows(m)
+
+    m.last_constraint_reference += 1
+    ref = VLCI{S}(m.last_constraint_reference)
+
+    dict = constrdict(m, ref)
+    dict[ref] = collect(nrows+1:nrows2)
+    for i in 1:MOI.dimension(set)
+        push!(m.constraint_primal_solution, NaN)
+        push!(m.constraint_dual_solution, NaN)
+        push!(m.constraint_constant, func.constant[i])
+    end
+    ref
+end
+
+function addlinearconstraint!(m::LinQuadOptimizer, func::VecLin, sense::Cchar)
+    @assert length(func.outputindex) == length(func.variables) == length(func.coefficients)
+    # get list of unique rows
+    rows = unique(func.outputindex)
+    @assert length(rows) == length(func.constant)
+    # sort into row order
+    pidx = sortperm(func.outputindex)
+    cols = getcol.(m, func.variables)[pidx]
+    vals = func.coefficients[pidx]
+    # loop through to gte starting position of each row
+    rowbegins = Vector{Int}(length(rows))
+    rowbegins[1] = 1
+    cnt = 1
+    for i in 2:length(pidx)
+        if func.outputindex[pidx[i]] != func.outputindex[pidx[i-1]]
+            cnt += 1
+            rowbegins[cnt] = i
+        end
+    end
+    lqs_addrows!(m, rowbegins, cols, vals, fill(sense, length(rows)), -func.constant)
+end
+
+MOI.canmodifyconstraint(m::LinQuadOptimizer, ::VLCI{<: VecLinSets}, ::Type{MOI.VectorConstantChange{Float64}}) = true
+function MOI.modifyconstraint!(m::LinQuadOptimizer, ref::VLCI{<: VecLinSets}, chg::MOI.VectorConstantChange{Float64})
+    @assert length(chg.new_constant) == length(m[ref])
+    for (r, v) in zip(m[ref], chg.new_constant)
+        lqs_chgcoef!(m, r, 0, -v)
+        m.constraint_constant[r] = v
+    end
+end
+
+#=
+    Constraint set of Linear function
+=#
+
+MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{VLCI{S}}) where S <: VecLinSets = true
+function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::VLCI{S}) where S <: VecLinSets
+    constraint_indices = m[c]
+    S(length(constraint_indices))
+end
+
+#=
+    Constraint function of Linear function
+=#
+
+MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{VLCI{S}}) where S <: VecLinSets = true
+function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::VLCI{<: VecLinSets})
+    ctrs = m[c]
+    n = length(ctrs)
+    out = MOI.VectorAffineFunction(Int[],VarInd[],Float64[],Float64[])
+    for i in 1:n
+        rhs = lqs_getrhs(m, ctrs[i])
+        push!(out.constant, -rhs)
+
+        # TODO more efficiently
+        colidx, coefs = lqs_getrows(m, ctrs[i])
+        append!(out.variables, m.variable_references[colidx+1])
+        append!(out.coefficients, coefs)
+        append!(out.outputindex, i*ones(Int,length(coefs)))
+    end
+    return out
+end

--- a/src/constraints/vectorofvariables.jl
+++ b/src/constraints/vectorofvariables.jl
@@ -1,0 +1,101 @@
+#=
+    Vector valued bounds
+        VectorOfVariables -in- Nonnegatives
+        VectorOfVariables -in- Nonpositives
+        VectorOfVariables -in- Zeros
+
+    SOS
+        VectorOfVariables -in- SOS1
+        VectorOfVariables -in- SOS2
+=#
+constrdict(m::LinQuadOptimizer, ::VVCI{MOI.Nonnegatives}) = cmap(m).vv_nonnegatives
+constrdict(m::LinQuadOptimizer, ::VVCI{MOI.Nonpositives}) = cmap(m).vv_nonpositives
+constrdict(m::LinQuadOptimizer, ::VVCI{MOI.Zeros}) = cmap(m).vv_zeros
+
+constrdict(m::LinQuadOptimizer, ::VVCI{SOS1}) = cmap(m).sos1
+constrdict(m::LinQuadOptimizer, ::VVCI{SOS2}) = cmap(m).sos2
+
+function MOI.addconstraint!(m::LinQuadOptimizer, func::VecVar, set::S) where S <: VecLinSets
+    @assert length(func.variables) == MOI.dimension(set)
+    m.last_constraint_reference += 1
+    ref = VVCI{S}(m.last_constraint_reference)
+    rows = lqs_getnumrows(m)
+    n = MOI.dimension(set)
+    lqs_addrows!(m, collect(1:n), getcol.(m, func.variables), ones(n), fill(lqs_char(m, set),n), zeros(n))
+    dict = constrdict(m, ref)
+    dict[ref] = collect(rows+1:rows+n)
+    append!(m.constraint_primal_solution, fill(NaN,n))
+    append!(m.constraint_dual_solution, fill(NaN,n))
+    append!(m.constraint_constant, fill(0.0,n))
+    return ref
+end
+
+
+#=
+    Get constraint set of vector variable bound
+=#
+
+MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{VVCI{S}}) where S <: VecLinSets = true
+function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::VVCI{S}) where S <: VecLinSets
+    S(length(m[c]))
+end
+
+#=
+    Get constraint function of vector variable bound (linear ctr)
+=#
+
+MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{VVCI{S}}) where S <: VecLinSets = true
+function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::VVCI{<: VecLinSets})
+    refs = m[c]
+    out = VarInd[]
+    sizehint!(out, length(refs))
+    for ref in refs
+        colidx, coefs = lqs_getrows(m, ref)
+        if length(colidx) != 1
+            error("Unexpected constraint")
+        end
+        push!(out,m.variable_references[colidx[1]+1])
+    end
+    return VecVar(out)
+end
+
+#=
+    SOS constraints
+=#
+
+function MOI.addconstraint!(m::LinQuadOptimizer, v::VecVar, sos::S) where S <: Union{MOI.SOS1, MOI.SOS2}
+    lqs_make_problem_type_integer(m)
+    lqs_addsos!(m, getcol.(m, v.variables), sos.weights, lqs_char(m, sos))
+    m.last_constraint_reference += 1
+    ref = VVCI{S}(m.last_constraint_reference)
+    dict = constrdict(m, ref)
+    dict[ref] = length(cmap(m).sos1) + length(cmap(m).sos2) + 1
+    ref
+end
+
+MOI.candelete(m::LinQuadOptimizer, c::VVCI{<:Union{SOS1, SOS2}}) = true
+function MOI.delete!(m::LinQuadOptimizer, c::VVCI{<:Union{SOS1, SOS2}})
+    deleteconstraintname!(m, c)
+    dict = constrdict(m, c)
+    idx = dict[c]
+    lqs_delsos!(m, idx, idx)
+    deleteref!(cmap(m).sos1, idx, c)
+    deleteref!(cmap(m).sos2, idx, c)
+    if !hasinteger(m)
+        lqs_make_problem_type_continuous(m)
+    end
+end
+
+MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{VVCI{S}}) where S <: Union{MOI.SOS1, MOI.SOS2} = true
+function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::VVCI{S}) where S <: Union{MOI.SOS1, MOI.SOS2}
+    indices, weights, types = lqs_getsos(m, m[c])
+    set = S(weights)
+    @assert types == lqs_char(m, set)
+    return set
+end
+
+MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{VVCI{S}}) where S <: Union{MOI.SOS1, MOI.SOS2} = true
+function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::VVCI{<:Union{SOS1, SOS2}})
+    indices, weights, types = lqs_getsos(m, m[c])
+    return VecVar(m.variable_references[indices])
+end

--- a/src/copy.jl
+++ b/src/copy.jl
@@ -6,8 +6,8 @@ MOI.canget(::LinQuadOptimizer, ::MOI.ListOfVariableAttributesSet) = true
 MOI.get(::LinQuadOptimizer, ::MOI.ListOfVariableAttributesSet) = MOI.AbstractVariableAttribute[]
 MOI.canget(::LinQuadOptimizer, ::MOI.ListOfModelAttributesSet) = true
 MOI.get(m::LinQuadOptimizer, ::MOI.ListOfModelAttributesSet) = [
-    MOI.ObjectiveSense,
-    MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}},
+    MOI.ObjectiveSense(),
+    MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
     (MOI.get(m, MOI.Name()) != "") ? MOI.Name() : nothing
 ]
 MOI.canget(::LinQuadOptimizer, ::MOI.ListOfConstraintAttributesSet{F,S}) where F where S = true

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -1,23 +1,51 @@
 #=
-    Set the objective
+    The Objective Sense
 =#
+
+MOI.canget(m::LinQuadOptimizer, ::MOI.ObjectiveSense) = true
+MOI.get(m::LinQuadOptimizer,::MOI.ObjectiveSense) = m.obj_sense
+
 MOI.canset(::LinQuadOptimizer, ::MOI.ObjectiveSense) = true
-MOI.canset(::LinQuadOptimizer, ::Type{MOI.ObjectiveSense}) = true
-MOI.set!(m::LinQuadOptimizer, ::Type{MOI.ObjectiveSense}, sense::MOI.OptimizationSense) = MOI.set!(m, MOI.ObjectiveSense(), sense)
 function MOI.set!(m::LinQuadOptimizer, ::MOI.ObjectiveSense, sense::MOI.OptimizationSense)
-    _setsense!(m, sense)
-    nothing
+    if sense == MOI.MinSense
+        lqs_chgobjsen!(m, :min)
+        m.obj_sense = MOI.MinSense
+    elseif sense == MOI.MaxSense
+        lqs_chgobjsen!(m, :max)
+        m.obj_sense = MOI.MaxSense
+    elseif sense == MOI.FeasibilitySense
+        # we set the objective sense to :min, and the objective to 0.0
+        lqs_chgobjsen!(m, :min)
+        unsafe_set!(m, MOI.ObjectiveFunction{Linear}(), MOI.ScalarAffineFunction(VarInd[],Float64[],0.0))
+        m.obj_is_quad = false
+        m.obj_sense = MOI.FeasibilitySense
+    else
+        error("Sense $(sense) unknown.")
+    end
 end
 
-MOI.canset(m::LinQuadOptimizer, ::Type{MOI.ObjectiveFunction{F}}) where F<:MOI.AbstractFunction = MOI.canset(m, MOI.ObjectiveFunction{F}())
+#=
+    The Objective Function
+=#
+
 function MOI.canset(m::LinQuadOptimizer, ::MOI.ObjectiveFunction{F}) where F<:MOI.AbstractFunction
+    if MOI.get(m, MOI.ObjectiveSense()) == MOI.FeasibilitySense
+        # it doesn't make sense to set an objective for a feasibility problem
+        return false
+    end
     return F in lqs_supported_objectives(m)
 end
-MOI.set!(m::LinQuadOptimizer, ::Type{MOI.ObjectiveFunction{F}}, objf::Linear) where F = MOI.set!(m, MOI.ObjectiveFunction{F}(), objf::Linear)
+
 function MOI.set!(m::LinQuadOptimizer, ::MOI.ObjectiveFunction{F}, objf::Linear) where F
     cobjf = MOIU.canonical(objf)
     unsafe_set!(m, MOI.ObjectiveFunction{Linear}(), cobjf)
 end
+
+"""
+    unsafe_set!(m, ::MOI.ObjectiveFunction{F}, objective::Linear) where F
+
+Sets a linear objective function without cannonicalizing `objective`.
+"""
 function unsafe_set!(m::LinQuadOptimizer, ::MOI.ObjectiveFunction{F}, objf::Linear) where F
     if m.obj_is_quad
         # previous objective was quadratic...
@@ -29,66 +57,6 @@ function unsafe_set!(m::LinQuadOptimizer, ::MOI.ObjectiveFunction{F}, objf::Line
     m.objective_constant = objf.constant
     nothing
 end
-
-#=
-    Set the objective sense
-=#
-
-function _setsense!(m::LinQuadOptimizer, sense::MOI.OptimizationSense)
-    if sense == MOI.MinSense
-        lqs_chgobjsen!(m, :min)
-        m.obj_sense = MOI.MinSense
-    elseif sense == MOI.MaxSense
-        lqs_chgobjsen!(m, :max)
-        m.obj_sense = MOI.MaxSense
-    elseif sense == MOI.FeasibilitySense
-        lqs_chgobjsen!(m, :min)
-        unsafe_set!(m, MOI.ObjectiveFunction{Linear}(), MOI.ScalarAffineFunction(VarInd[],Float64[],0.0))
-        m.obj_is_quad = false
-        m.obj_sense = MOI.FeasibilitySense
-    else
-        error("Sense $(sense) unknown.")
-    end
-end
-
-#=
-    Get the objective sense
-=#
-
-MOI.get(m::LinQuadOptimizer,::MOI.ObjectiveSense) = m.obj_sense#lqs_getobjsen(m)
-MOI.get(m::LinQuadOptimizer,::Type{MOI.ObjectiveSense}) = m.obj_sense#lqs_getobjsen(m)
-MOI.canget(m::LinQuadOptimizer, ::MOI.ObjectiveSense) = true
-MOI.canget(m::LinQuadOptimizer, ::Type{MOI.ObjectiveSense}) = true
-
-#=
-    Get the objective function
-=#
-
-MOI.get(m::LinQuadOptimizer, ::Type{MOI.ObjectiveFunction{Linear}}) = MOI.get(m, MOI.ObjectiveFunction{Linear}())
-function MOI.get(m::LinQuadOptimizer, ::MOI.ObjectiveFunction{Linear})
-    variable_coefficients = lqs_getobj(m)
-    Linear(m.variable_references, variable_coefficients, m.objective_constant)
-end
-# can't get quadratic objective functions
-MOI.canget(m::LinQuadOptimizer, ::MOI.ObjectiveFunction{S}) where S = false
-MOI.canget(m::LinQuadOptimizer, ::Type{MOI.ObjectiveFunction{S}}) where S = false
-MOI.canget(m::LinQuadOptimizer, ::MOI.ObjectiveFunction{Linear}) = !m.obj_is_quad
-MOI.canget(m::LinQuadOptimizer, ::Type{MOI.ObjectiveFunction{Linear}}) = !m.obj_is_quad
-
-#=
-    Modify objective function
-=#
-
-function MOI.modifyobjective!(m::LinQuadOptimizer, chg::MOI.ScalarCoefficientChange{Float64})
-    col = m.variable_mapping[chg.variable]
-    # 0 row is the objective
-    lqs_chgcoef!(m, 0, col, chg.new_coefficient)
-end
-MOI.canmodifyobjective(m::LinQuadOptimizer, ::Type{MOI.ScalarCoefficientChange{Float64}}) = true
-
-#=
-    Set quadratic objective
-=#
 
 function MOI.set!(m::LinQuadOptimizer, ::MOI.ObjectiveFunction, objf::Quad)
     m.obj_is_quad = true
@@ -108,4 +76,25 @@ function MOI.set!(m::LinQuadOptimizer, ::MOI.ObjectiveFunction, objf::Quad)
     )
     m.objective_constant = objf.constant
     nothing
+end
+
+#=
+    Get the objective function
+=#
+
+MOI.canget(m::LinQuadOptimizer, ::MOI.ObjectiveFunction{Linear}) = !m.obj_is_quad
+function MOI.get(m::LinQuadOptimizer, ::MOI.ObjectiveFunction{Linear})
+    variable_coefficients = lqs_getobj(m)
+    Linear(m.variable_references, variable_coefficients, m.objective_constant)
+end
+
+#=
+    Modify objective function
+=#
+
+MOI.canmodifyobjective(m::LinQuadOptimizer, ::Type{MOI.ScalarCoefficientChange{Float64}}) = true
+function MOI.modifyobjective!(m::LinQuadOptimizer, chg::MOI.ScalarCoefficientChange{Float64})
+    col = m.variable_mapping[chg.variable]
+    # 0 row is the objective
+    lqs_chgcoef!(m, 0, col, chg.new_coefficient)
 end

--- a/src/solver_interface.jl
+++ b/src/solver_interface.jl
@@ -18,6 +18,60 @@
 =#
 
 """
+    lqs_char(m, ::MOI.AbstractSet)::CChar
+
+Return a Cchar specifiying the constraint set sense.
+
+Interval constraints are sometimes called range constraints and have the form
+`l <= a'x <= u`
+
+Three are special cases:
+ - `Val{:Continuous}`: Cchar for a continuous variable
+ - `Val{:Upperbound}`: Cchar for the upper bound of a variable
+ - `Val{:Lowerbound}`: Cchar for the lower bound of a variable
+
+### Defaults
+
+    MOI.GreaterThan  - 'G'
+    MOI.LessThan     - 'L'
+    MOI.EqualTo      - 'E'
+    MOI.Interval     - 'R'
+
+    MOI.Zeros        - 'E'
+    MOI.Nonpositives - 'L'
+    MOI.Nonnegatives - 'G'
+
+    MOI.ZeroOne - 'B'
+    MOI.Integer - 'I'
+
+    MOI.SOS1 - :SOS1  # '1'
+    MOI.SOS2 - :SOS2  # '2'
+
+    Val{:Continuous} - 'C'
+    Val{:Upperbound} - 'U'
+    Val{:Lowerbound} - 'L'
+"""
+lqs_char(m::LinQuadOptimizer, ::MOI.GreaterThan{T}) where T = Cchar('G')
+lqs_char(m::LinQuadOptimizer, ::MOI.LessThan{T}) where T    = Cchar('L')
+lqs_char(m::LinQuadOptimizer, ::MOI.EqualTo{T}) where T     = Cchar('E')
+lqs_char(m::LinQuadOptimizer, ::MOI.Interval{T}) where T    = Cchar('R')
+
+lqs_char(m::LinQuadOptimizer, ::MOI.Zeros)        = Cchar('E')
+lqs_char(m::LinQuadOptimizer, ::MOI.Nonpositives) = Cchar('L')
+lqs_char(m::LinQuadOptimizer, ::MOI.Nonnegatives) = Cchar('G')
+
+lqs_char(m::LinQuadOptimizer, ::MOI.ZeroOne) = Cchar('B')
+lqs_char(m::LinQuadOptimizer, ::MOI.Integer) = Cchar('I')
+
+lqs_char(m::LinQuadOptimizer, ::MOI.SOS1{T}) where T = :SOS1  # Cchar('1')
+lqs_char(m::LinQuadOptimizer, ::MOI.SOS2{T}) where T = :SOS2  # Cchar('2')
+
+
+lqs_char(m::LinQuadOptimizer, ::Val{:Continuous}) = Cchar('C')
+lqs_char(m::LinQuadOptimizer, ::Val{:Upperbound}) = Cchar('U')
+lqs_char(m::LinQuadOptimizer, ::Val{:Lowerbound}) = Cchar('L')
+
+"""
     LinQuadModel(M::Type{<:LinQuadOptimizer}, env)
 
 Initializes a model given a model type `M` and an `env` that might be a `nothing`
@@ -161,15 +215,6 @@ Ranged constraints (sense=`:RANGE`) require a call to `lqs_chgrngval!`.
 """
 function lqs_chgsense!(m::LinQuadOptimizer, rows, sense) end
 
-# TODO(@joaquim): again, why not a function?
-"""
-    lqs_vartype_map(m)::Dict
-
-Returns a dictionary that maps the variable type to an appropriate backend type.
-Variable type must be `:CONTINUOUS`, `:INTEGER`, or `:BINARY`.
-"""
-function lqs_vartype_map(m::LinQuadOptimizer) end
-
 """
     lqs_make_problem_type_integer(m)::Void
 
@@ -198,15 +243,6 @@ Delete the SOS constraints `start_idx`, `start_idx+1`, ..., `end_idx` from
 the model `m`.
 """
 function lqs_delsos!(m::LinQuadOptimizer, start_idx, end_idx) end
-
-# TODO(@joaquim): what is sertype. Why not a function?
-"""
-    lqs_sertype_map(m)::Dict
-
-Returns a dictionary that maps  `:SOS1` and `:SOS2` to an appropriate type for
-the backend.
-"""
-function lqs_sertype_map(m::LinQuadOptimizer) end
 
 """
     lqs_getsos(m, idx::Int)::Tuple{Vector{Int}, Vector{Float64}, Symbol}
@@ -243,17 +279,6 @@ A range constraint `l <= a'x <= u` is added as the linear constraint
 See `lqs_addrows!` for more.
 """
 function lqs_chgrngval!(m::LinQuadOptimizer, rows, vals) end# later
-
-# TODO(@joaquim): Why not a function?
-"""
-    lqs_ctrtype_map(m)::Dict
-
-Returns a dictionary that maps the constraint type to an appropriate type for
-the backend.
-
-The constraint type is one of `:RANGE`, `:LOWER`, `:UPPER`, `:EQUALITY`.
-"""
-function lqs_ctrtype_map(m::LinQuadOptimizer) end
 
 #Objective
 """


### PR DESCRIPTION
This PR tidies up LQOI.

The first commit
 - splits the file `constraints.jl` into multiple files based on the `ConstraintFunction`. This makes it easier to see which `Function-in-Set` pairs are implemented, and which support `modify!`, `delete!` etc.
 - removes the `get(m, ::Attribute, v::Index)` methods since MOI defines `get(m, ::Attribute, ::Type{Index})`
 - sets the default sense to `MinSense`. 
 - removes the dictionary lookups in favour of an overloadable `lqs_char(m, ::Set)` method. For example,
GLPK retains the default `lqs_char(m, ::LessThan) = Cchar('L')`, while Gurobi overloads `lqs_char(m::GurobiOptimizer, ::LessThan) = Cchar('<=')`.

<s>The second commit begins a rename of the solver-facing API. Name suggestions are appreciated.</s> Will make a new PR