### PR TITLE
WIP: fix issues identified by MOI #354

### DIFF
--- a/src/LinQuadOptInterface.jl
+++ b/src/LinQuadOptInterface.jl
@@ -101,6 +101,42 @@ ConstraintMapping() = ConstraintMapping(
     Dict{VVCI{SOS1}, Int}(),
     Dict{VVCI{SOS2}, Int}()
 )
+
+"""
+    shift_references_after_delete_affine!(m, row)
+
+This function updates all of the references in `m`
+after we have deleted row `row` in the affine constraint matrix.
+"""
+function shift_references_after_delete_affine!(m, row)
+    for scalar_affine in [
+            cmap(m).less_than,
+            cmap(m).greater_than,
+            cmap(m).equal_to,
+            cmap(m).interval
+        ]
+        for (key, val) in scalar_affine
+            if val > row
+                scalar_affine[key] -= 1
+            end
+        end
+    end
+
+    for vector_affine in [
+            cmap(m).vv_nonnegatives,
+            cmap(m).vv_nonpositives,
+            cmap(m).vv_zeros
+        ]
+        for (key, vals) in vector_affine
+            for (i, val) in enumerate(vals)
+                if val > row
+                    vector_affine[key][i] -= 1
+                end
+            end
+        end
+    end
+end
+
 function Base.isempty(map::ConstraintMapping)
 
     ret = true

--- a/src/LinQuadOptInterface.jl
+++ b/src/LinQuadOptInterface.jl
@@ -77,6 +77,9 @@ struct ConstraintMapping
     binary::Dict{SVCI{MOI.ZeroOne}, Tuple{VarInd, Float64, Float64}}
     sos1::Dict{VVCI{SOS1}, Int}
     sos2::Dict{VVCI{SOS2}, Int}
+    semicontinuous::Dict{SVCI{MOI.Semicontinuous{Float64}}, VarInd}
+    semiinteger::Dict{SVCI{MOI.Semiinteger{Float64}}, VarInd}
+
 end
 ConstraintMapping() = ConstraintMapping(
     Dict{LCI{LE}, Int}(),
@@ -99,7 +102,9 @@ ConstraintMapping() = ConstraintMapping(
     Dict{SVCI{MOI.Integer}, VarInd}(),
     Dict{SVCI{MOI.ZeroOne}, Tuple{VarInd, Float64, Float64}}(),
     Dict{VVCI{SOS1}, Int}(),
-    Dict{VVCI{SOS2}, Int}()
+    Dict{VVCI{SOS2}, Int}(),
+    Dict{SVCI{MOI.Semicontinuous{Float64}}, VarInd}(),
+    Dict{SVCI{MOI.Semiinteger{Float64}}, VarInd}()
 )
 
 """
@@ -181,6 +186,8 @@ function Base.isempty(map::ConstraintMapping)
     ret = ret && isempty(map.binary)
     ret = ret && isempty(map.sos1)
     ret = ret && isempty(map.sos2)
+    ret = ret && isempty(map.semiinteger)
+    ret = ret && isempty(map.semicontinuous)
 
     return ret
 end

--- a/src/LinQuadOptInterface.jl
+++ b/src/LinQuadOptInterface.jl
@@ -137,6 +137,26 @@ function shift_references_after_delete_affine!(m, row)
     end
 end
 
+"""
+    shift_references_after_delete_quadratic!(m, row)
+
+This function updates all of the references in `m`
+after we have deleted row `row` in the quadratic constraint matrix.
+"""
+function shift_references_after_delete_quadratic!(m, row)
+    for scalar_quadratic in [
+            cmap(m).q_less_than,
+            cmap(m).q_greater_than,
+            cmap(m).q_equal_to
+        ]
+        for (key, val) in scalar_quadratic
+            if val > row
+                scalar_quadratic[key] -= 1
+            end
+        end
+    end
+end
+
 function Base.isempty(map::ConstraintMapping)
 
     ret = true

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -26,10 +26,18 @@ end
     hasinteger(m::LinQuadOptimizer)::Bool
 
 A helper function to determine if the solver instance `m` has any integer
-components (i.e. binary, integer, special ordered sets, etc).
+components (i.e. binary, integer, special ordered sets, semicontinuous, or
+semi-integer variables).
 """
 function hasinteger(m::LinQuadOptimizer)
-    length(cmap(m).integer) + length(cmap(m).binary) + length(cmap(m).sos1) + length(cmap(m).sos2) > 0
+    (
+        length(cmap(m).integer) +
+        length(cmap(m).binary) +
+        length(cmap(m).sos1) +
+        length(cmap(m).sos2) +
+        length(cmap(m).semicontinuous) +
+        length(cmap(m).semiinteger)
+                ) > 0
 end
 
 #=

--- a/src/constraints/scalaraffine.jl
+++ b/src/constraints/scalaraffine.jl
@@ -84,7 +84,7 @@ function addlinearconstraints!(m::LinQuadOptimizer, func::Vector{Linear}, set::V
     coefficients   = Vector{Float64}(nnz)       # corresponding non-zeros
     i = 1
     for (fi, f) in enumerate(func)
-        row_starts[fi] = cnt
+        row_starts[fi] = i
         for (var, coef) in zip(f.variables, f.coefficients)
             column_indices[i] = getcol(m, var)
             coefficients[i]   = coef
@@ -128,6 +128,13 @@ function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::LCI{S}) where S <:
     rhs = get_rhs(m, m[c])
     S(rhs+m.constraint_constant[m[c]])
 end
+
+MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{LCI{IV}}) = false
+# TODO(odow): get constraint sets for ranged constraints.
+# function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::LCI{IV})
+#     ???
+#     IV(lowerbound+m.constraint_constant[m[c]], upperbound + m.constraint_constant[m[c]])
+# end
 
 #=
     Constraint function of Linear function

--- a/src/constraints/scalaraffine.jl
+++ b/src/constraints/scalaraffine.jl
@@ -185,13 +185,9 @@ function MOI.delete!(m::LinQuadOptimizer, c::LCI{<: LinSets})
     deleteat!(m.constraint_primal_solution, row)
     deleteat!(m.constraint_dual_solution, row)
     deleteat!(m.constraint_constant, row)
-    deleteref!(m, row, c)
-end
-function deleteref!(m::LinQuadOptimizer, row::Int, ref::LCI{<: LinSets})
-    deleteref!(cmap(m).less_than, row, ref)
-    deleteref!(cmap(m).greater_than, row, ref)
-    deleteref!(cmap(m).equal_to, row, ref)
-    deleteref!(cmap(m).interval, row, ref)
+    # shift all the other references
+    shift_references_after_delete_affine!(m, row)
+    delete!(dict, c)
 end
 
 #=

--- a/src/constraints/scalaraffine.jl
+++ b/src/constraints/scalaraffine.jl
@@ -176,7 +176,7 @@ end
     Delete a linear constraint
 =#
 
-MOI.candelete(m::LinQuadOptimizer, c::LCI{<: LinSets}) = true
+MOI.candelete(m::LinQuadOptimizer, c::LCI{<: LinSets}) = MOI.isvalid(m, c)
 function MOI.delete!(m::LinQuadOptimizer, c::LCI{<: LinSets})
     deleteconstraintname!(m, c)
     dict = constrdict(m, c)

--- a/src/constraints/scalarquadratic.jl
+++ b/src/constraints/scalarquadratic.jl
@@ -66,3 +66,17 @@ function reduceduplicates(rowi::Vector{T}, coli::Vector{T}, vals::Vector{S}) whe
     end
     ri, ci, vi
 end
+
+
+MOI.candelete(m::LinQuadOptimizer, c::QCI{<: LinSets}) = MOI.isvalid(m, c)
+function MOI.delete!(m::LinQuadOptimizer, c::QCI{<: LinSets})
+    deleteconstraintname!(m, c)
+    dict = constrdict(m, c)
+    row = dict[c]
+    delete_quadratic_constraints!(m, row, row)
+    deleteat!(m.qconstraint_primal_solution, row)
+    deleteat!(m.qconstraint_dual_solution, row)
+    # shift all the other references
+    shift_references_after_delete_quadratic!(m, row)
+    delete!(dict, c)
+end

--- a/src/constraints/singlevariable.jl
+++ b/src/constraints/singlevariable.jl
@@ -5,11 +5,10 @@
         SingleVariable -in- EqualTo
         SingleVariable -in- Interval
 
-TODO
-
-    Binary
         SingleVariable -in- ZeroOne
         SingleVariable -in- Integer
+        SingleVariable -in- Semiinteger
+        SingleVariable -in- Semicontinuous
 =#
 constrdict(m::LinQuadOptimizer, ::SVCI{LE}) = cmap(m).upper_bound
 constrdict(m::LinQuadOptimizer, ::SVCI{GE}) = cmap(m).lower_bound
@@ -18,6 +17,9 @@ constrdict(m::LinQuadOptimizer, ::SVCI{IV}) = cmap(m).interval_bound
 
 constrdict(m::LinQuadOptimizer, ::SVCI{MOI.ZeroOne}) = cmap(m).binary
 constrdict(m::LinQuadOptimizer, ::SVCI{MOI.Integer}) = cmap(m).integer
+
+constrdict(m::LinQuadOptimizer, ::SVCI{MOI.Semicontinuous{Float64}}) = cmap(m).semicontinuous
+constrdict(m::LinQuadOptimizer, ::SVCI{MOI.Semiinteger{Float64}}) = cmap(m).semiinteger
 
 function setvariablebound!(m::LinQuadOptimizer, col::Int, bound::Float64, sense::Cchar)
     change_variable_bounds!(m, [col], [bound], [sense])
@@ -167,3 +169,46 @@ MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{MOI.Integer}) = MOI.In
 
 MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{SVCI{MOI.Integer}}) = true
 MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{MOI.Integer}) = SinVar(m[c])
+
+#=
+    Semicontinuous / Semiinteger constraints
+=#
+const SEMI_TYPES = Union{MOI.Semicontinuous{Float64}, MOI.Semiinteger{Float64}}
+function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::SEMI_TYPES)
+    change_variable_types!(m, [getcol(m, v)], [backend_type(m, set)])
+    setvariablebound!(m, getcol(m, v), set.upper, backend_type(m, Val{:Upperbound}()))
+    setvariablebound!(m, getcol(m, v), set.lower, backend_type(m, Val{:Lowerbound}()))
+
+    m.last_constraint_reference += 1
+    ref = SVCI{typeof(set)}(m.last_constraint_reference)
+    dict = constrdict(m, ref)
+    dict[ref] = v.variable
+    make_problem_type_integer(m)
+    ref
+end
+
+MOI.candelete(m::LinQuadOptimizer, c::SVCI{<:SEMI_TYPES}) = MOI.isvalid(m, c)
+function MOI.delete!(m::LinQuadOptimizer, c::SVCI{<:SEMI_TYPES})
+    deleteconstraintname!(m, c)
+    dict = constrdict(m, c)
+    v = dict[c]
+    change_variable_types!(m, [getcol(m, v)], [backend_type(m, Val{:Continuous}())])
+    setvariablebound!(m, getcol(m, v), Inf, backend_type(m, Val{:Upperbound}()))
+    setvariablebound!(m, getcol(m, v), -Inf, backend_type(m, Val{:Lowerbound}()))
+    delete!(dict, c)
+    if !hasinteger(m)
+        make_problem_type_continuous(m)
+    end
+end
+
+MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{SVCI{S}}) where S <:SEMI_TYPES = true
+function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{S}) where S <: SEMI_TYPES
+    dict = constrdict(m, c)
+    v = dict[c]
+    lb = get_variable_lowerbound(m, getcol(m, v))
+    ub = get_variable_upperbound(m, getcol(m, v))
+    return S(lb, ub)
+end
+
+MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{SVCI{S}}) where S <:SEMI_TYPES = true
+MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{<:SEMI_TYPES}) = SinVar(m[c])

--- a/src/constraints/singlevariable.jl
+++ b/src/constraints/singlevariable.jl
@@ -49,7 +49,7 @@ function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::S) where S <: L
 end
 
 # delete constraint
-MOI.candelete(m::LinQuadOptimizer, c::SVCI{S}) where S <: LinSets = true
+MOI.candelete(m::LinQuadOptimizer, c::SVCI{S}) where S <: LinSets = MOI.isvalid(m, c)
 function MOI.delete!(m::LinQuadOptimizer, c::SVCI{S}) where S <: LinSets
     deleteconstraintname!(m, c)
     dict = constrdict(m, c)
@@ -116,7 +116,7 @@ function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::MOI.ZeroOne)
     ref
 end
 
-MOI.candelete(m::LinQuadOptimizer, c::SVCI{MOI.ZeroOne}) = true
+MOI.candelete(m::LinQuadOptimizer, c::SVCI{MOI.ZeroOne}) = MOI.isvalid(m, c)
 function MOI.delete!(m::LinQuadOptimizer, c::SVCI{MOI.ZeroOne})
     deleteconstraintname!(m, c)
     dict = constrdict(m, c)
@@ -150,6 +150,7 @@ function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::MOI.Integer)
     ref
 end
 
+MOI.candelete(m::LinQuadOptimizer, c::SVCI{MOI.Integer}) = MOI.isvalid(m, c)
 function MOI.delete!(m::LinQuadOptimizer, c::SVCI{MOI.Integer})
     deleteconstraintname!(m, c)
     dict = constrdict(m, c)
@@ -160,7 +161,6 @@ function MOI.delete!(m::LinQuadOptimizer, c::SVCI{MOI.Integer})
         make_problem_type_continuous(m)
     end
 end
-MOI.candelete(m::LinQuadOptimizer, c::SVCI{MOI.Integer}) = true
 
 MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{SVCI{MOI.Integer}}) = true
 MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{MOI.Integer}) = MOI.Integer()

--- a/src/constraints/singlevariable.jl
+++ b/src/constraints/singlevariable.jl
@@ -134,7 +134,7 @@ MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{SVCI{MOI.ZeroOne}}) 
 MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{MOI.ZeroOne}) = MOI.ZeroOne()
 
 MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{SVCI{MOI.ZeroOne}}) = true
-MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{MOI.ZeroOne}) = SinVar(m[c])
+MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{MOI.ZeroOne}) = SinVar(m[c][1])
 
 #=
     Integer constraints

--- a/src/constraints/singlevariable.jl
+++ b/src/constraints/singlevariable.jl
@@ -134,7 +134,7 @@ MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{SVCI{MOI.ZeroOne}}) 
 MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{MOI.ZeroOne}) = MOI.ZeroOne()
 
 MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{SVCI{MOI.ZeroOne}}) = true
-MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{MOI.ZeroOne}) = m[c]
+MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{MOI.ZeroOne}) = SinVar(m[c])
 
 #=
     Integer constraints
@@ -165,5 +165,5 @@ MOI.candelete(m::LinQuadOptimizer, c::SVCI{MOI.Integer}) = true
 MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{SVCI{MOI.Integer}}) = true
 MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{MOI.Integer}) = MOI.Integer()
 
-MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{MOI.Integer}) = m[c]
 MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{SVCI{MOI.Integer}}) = true
+MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{MOI.Integer}) = SinVar(m[c])

--- a/src/constraints/vectoraffine.jl
+++ b/src/constraints/vectoraffine.jl
@@ -60,7 +60,10 @@ MOI.candelete(m::LinQuadOptimizer, c::VLCI{<:VecLinSets}) = MOI.isvalid(m, c)
 function MOI.delete!(m::LinQuadOptimizer, c::VLCI{<:VecLinSets})
     deleteconstraintname!(m, c)
     dict = constrdict(m, c)
-    for row in copy(dict[c])  # put a copy here because we modify in the loop
+    # we delete rows from largest to smallest here so that we don't have
+    # to worry about updating references in a greater numbered row, only to
+    # modify it later.
+    for row in sort(dict[c], rev=true)
         delete_linear_constraints!(m, row, row)
         deleteat!(m.constraint_primal_solution, row)
         deleteat!(m.constraint_dual_solution, row)

--- a/src/constraints/vectoraffine.jl
+++ b/src/constraints/vectoraffine.jl
@@ -56,7 +56,7 @@ function MOI.modifyconstraint!(m::LinQuadOptimizer, ref::VLCI{<: VecLinSets}, ch
     end
 end
 
-MOI.candelete(m::LinQuadOptimizer, c::VLCI{<:VecLinSets}) = true
+MOI.candelete(m::LinQuadOptimizer, c::VLCI{<:VecLinSets}) = MOI.isvalid(m, c)
 function MOI.delete!(m::LinQuadOptimizer, c::VLCI{<:VecLinSets})
     deleteconstraintname!(m, c)
     dict = constrdict(m, c)

--- a/src/constraints/vectoraffine.jl
+++ b/src/constraints/vectoraffine.jl
@@ -56,6 +56,22 @@ function MOI.modifyconstraint!(m::LinQuadOptimizer, ref::VLCI{<: VecLinSets}, ch
     end
 end
 
+MOI.candelete(m::LinQuadOptimizer, c::VLCI{<:VecLinSets}) = true
+function MOI.delete!(m::LinQuadOptimizer, c::VLCI{<:VecLinSets})
+    deleteconstraintname!(m, c)
+    dict = constrdict(m, c)
+    for row in copy(dict[c])  # put a copy here because we modify in the loop
+        delete_linear_constraints!(m, row, row)
+        deleteat!(m.constraint_primal_solution, row)
+        deleteat!(m.constraint_dual_solution, row)
+        deleteat!(m.constraint_constant, row)
+        # shift all the other references
+        shift_references_after_delete_affine!(m, row)
+    end
+    delete!(dict, c)
+end
+
+
 #=
     Constraint set of Linear function
 =#

--- a/src/constraints/vectorofvariables.jl
+++ b/src/constraints/vectorofvariables.jl
@@ -34,7 +34,10 @@ MOI.candelete(m::LinQuadOptimizer, c::VVCI{S}) where S <: VecLinSets = MOI.isval
 function MOI.delete!(m::LinQuadOptimizer, c::VVCI{S}) where S <: VecLinSets
     deleteconstraintname!(m, c)
     dict = constrdict(m, c)
-    for row in copy(dict[c])
+    # we delete rows from largest to smallest here so that we don't have
+    # to worry about updating references in a greater numbered row, only to
+    # modify it later.
+    for row in sort(dict[c], rev=true)
         delete_linear_constraints!(m, row, row)
         deleteat!(m.constraint_primal_solution, row)
         deleteat!(m.constraint_dual_solution, row)

--- a/src/constraints/vectorofvariables.jl
+++ b/src/constraints/vectorofvariables.jl
@@ -30,7 +30,7 @@ function MOI.addconstraint!(m::LinQuadOptimizer, func::VecVar, set::S) where S <
     return ref
 end
 
-MOI.candelete(m::LinQuadOptimizer, c::VVCI{S}) where S <: VecLinSets = true
+MOI.candelete(m::LinQuadOptimizer, c::VVCI{S}) where S <: VecLinSets = MOI.isvalid(m, c)
 function MOI.delete!(m::LinQuadOptimizer, c::VVCI{S}) where S <: VecLinSets
     deleteconstraintname!(m, c)
     dict = constrdict(m, c)
@@ -87,7 +87,7 @@ function MOI.addconstraint!(m::LinQuadOptimizer, v::VecVar, sos::S) where S <: U
     ref
 end
 
-MOI.candelete(m::LinQuadOptimizer, c::VVCI{<:Union{SOS1, SOS2}}) = true
+MOI.candelete(m::LinQuadOptimizer, c::VVCI{<:Union{SOS1, SOS2}}) = MOI.isvalid(m, c)
 function MOI.delete!(m::LinQuadOptimizer, c::VVCI{<:Union{SOS1, SOS2}})
     deleteconstraintname!(m, c)
     dict = constrdict(m, c)

--- a/src/constraints/vectorofvariables.jl
+++ b/src/constraints/vectorofvariables.jl
@@ -30,6 +30,20 @@ function MOI.addconstraint!(m::LinQuadOptimizer, func::VecVar, set::S) where S <
     return ref
 end
 
+MOI.candelete(m::LinQuadOptimizer, c::VVCI{S}) where S <: VecLinSets = true
+function MOI.delete!(m::LinQuadOptimizer, c::VVCI{S}) where S <: VecLinSets
+    deleteconstraintname!(m, c)
+    dict = constrdict(m, c)
+    for row in copy(dict[c])
+        delete_linear_constraints!(m, row, row)
+        deleteat!(m.constraint_primal_solution, row)
+        deleteat!(m.constraint_dual_solution, row)
+        deleteat!(m.constraint_constant, row)
+        # shift all the other references
+        shift_references_after_delete_affine!(m, row)
+    end
+    delete!(dict, c)
+end
 
 #=
     Get constraint set of vector variable bound

--- a/src/solver_interface.jl
+++ b/src/solver_interface.jl
@@ -219,6 +219,14 @@ function delete_linear_constraints! end
 @deprecate lqs_delrows! delete_linear_constraints!
 
 """
+    delete_quadratic_constraints!(m, start_row::Int, end_row::Int)::Void
+
+Delete the quadratic constraints `start_row`, `start_row+1`, ..., `end_row` from
+the model `m`.
+"""
+function delete_quadratic_constraints! end
+
+"""
     lqs_chgctype(m, cols::Vector{Int}, types):Void
 
 Change the variable types. Type is the output of one of:

--- a/src/solver_interface.jl
+++ b/src/solver_interface.jl
@@ -40,8 +40,10 @@ Three are special cases:
     MOI.Nonpositives - 'L'
     MOI.Nonnegatives - 'G'
 
-    MOI.ZeroOne - 'B'
-    MOI.Integer - 'I'
+    MOI.ZeroOne        - 'B'
+    MOI.Integer        - 'I'
+    MOI.Semicontinuous - 'S'
+    MOI.Semiinteger    - 'N'
 
     MOI.SOS1 - :SOS1  # '1'
     MOI.SOS2 - :SOS2  # '2'
@@ -66,6 +68,8 @@ backend_type(m::LinQuadOptimizer, ::MOI.Integer) = Cchar('I')
 backend_type(m::LinQuadOptimizer, ::MOI.SOS1{T}) where T = :SOS1  # Cchar('1')
 backend_type(m::LinQuadOptimizer, ::MOI.SOS2{T}) where T = :SOS2  # Cchar('2')
 
+backend_type(m::LinQuadOptimizer, ::MOI.Semicontinuous{T}) where T = Cchar('S')
+backend_type(m::LinQuadOptimizer, ::MOI.Semiinteger{T}) where T    = Cchar('N')
 
 backend_type(m::LinQuadOptimizer, ::Val{:Continuous}) = Cchar('C')
 backend_type(m::LinQuadOptimizer, ::Val{:Upperbound}) = Cchar('U')


### PR DESCRIPTION
Refs https://github.com/JuliaOpt/MathOptInterface.jl/pull/354, https://github.com/JuliaOpt/LinQuadOptInterface.jl/issues/8

##### New functionality
- support deleting VectorOfVariables-in-{Zeros,Nonnegatives,Nonpositives}
- support deleting VectorAffineFunction-in-{Zeros,Nonnegatives,Nonpositives}
- support deleting ScalarQuadraticFunctions _including_ a new API method.
- Semi-integer and Semicontinuous variables

##### Fixes the following bugs
- incorrect return from get ConstraintFunction for SingleVariable-in-ZeroOne and SingleVariable-in-Integer
- deleting scalaraffine constraints ignored the fact that there might be vectoraffine constraints as well
- typo in addlinearconstraints!
- candelete should check that the reference is valid. But, see https://github.com/JuliaOpt/MathOptInterface.jl/issues/218