### PR TITLE
Add get_quadratic_constraint and fix getting of quadratic function

### DIFF
--- a/src/constraints/scalaraffine.jl
+++ b/src/constraints/scalaraffine.jl
@@ -137,7 +137,7 @@ function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::LCI{S}) where S <:
     S(rhs+m.constraint_constant[m[c]])
 end
 
-MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{LCI{IV}}) = false
+MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{LCI{IV}}) = true
 function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::LCI{IV})
     lowerbound, upperbound = get_range(m, m[c])
     IV(lowerbound+m.constraint_constant[m[c]], upperbound + m.constraint_constant[m[c]])

--- a/src/constraints/scalarquadratic.jl
+++ b/src/constraints/scalarquadratic.jl
@@ -103,7 +103,7 @@ end
 
 MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{QCI{S}}) where S <: Union{LE, GE, EQ} = true
 function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::QCI{S}) where S <: Union{LE, GE, EQ}
-    rhs = get_rhs(m, m[c])
+    rhs = get_quadratic_rhs(m, m[c])
     S(rhs)
 end
 
@@ -118,8 +118,8 @@ function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::QCI{<: LinSet
     # TODO more efficiently
     colidx, coefs, Q = get_quadratic_constraint(m, m[c])
     affine_terms = map(
-        (v,c)->MOI.ScalarAffineTerm{Float64}(c,v),
-        m.variable_references[colidx+1],
+        (v,c)->MOI.ScalarAffineTerm{Float64}(c, m.variable_references[v]),
+        colidx,
         coefs
     )
     rows = rowvals(Q)

--- a/src/solver_interface.jl
+++ b/src/solver_interface.jl
@@ -352,6 +352,13 @@ Where `Q` represents the matrix in CSC format.
 function get_quadratic_constraint end
 
 """
+    get_quadratic_constraint(m, row::Int)::Float64
+
+Get the right hand-side term of quadratic constraint in row `row` in model `m`.
+"""
+function get_quadratic_rhs end
+
+"""
     set_linear_objective!(m, cols::Vector{Int}, coefs::Vector{Float64})::Void
 
 Set the linear component of the objective.


### PR DESCRIPTION
@joaquimg  I'm not sure what the story is with Xpress but I needed these changes for Gurobi.

In particular, Gurobi counts linear rows separately from quadratic rows :(

The docs also say that `get_quadratic_constraint` returns 1-indexed columns. We probably need to check that this happens everywhere?