### PR TITLE
Allow setting scalar affine constraint functions via the modification API

### DIFF
--- a/src/constraints/scalaraffine.jl
+++ b/src/constraints/scalaraffine.jl
@@ -211,7 +211,8 @@ function MOI.set!(model::LinQuadOptimizer, ::MOI.ConstraintSet, index::LCI{IV},
                   new_set::IV)
     row = model[index]
     constant = model.constraint_constant[row]
-    modify_ranged_constraints!(model, [model[index]], [new_set.lower - constant], [new_set.upper - constant])
+    modify_ranged_constraints!(model, [model[index]],
+        [new_set.lower - constant], [new_set.upper - constant])
 end
 
 #=

--- a/src/constraints/scalaraffine.jl
+++ b/src/constraints/scalaraffine.jl
@@ -265,7 +265,7 @@ function MOI.set!(model::LinQuadOptimizer, attr::MOI.ConstraintFunction, CI::LCI
     end
     change_rhs_coefficient!(model, row, get_rhs(model, row) - (replacement.constant - previous.constant))
     model.constraint_constant[model[CI]] = replacement.constant
-    nothing
+    return nothing
 end
 
 #=

--- a/src/constraints/scalaraffine.jl
+++ b/src/constraints/scalaraffine.jl
@@ -209,10 +209,8 @@ function MOI.set!(m::LinQuadOptimizer, attr::MOI.ConstraintFunction, CI::LCI{S},
         chg = MOI.ScalarCoefficientChange{Float64}(var, term.coefficient)
         MOI.modify!(m, CI, chg)
     end
-    if !iszero(previous.constant) || !iszero(replacement.constant)
-        current_set = MOI.get(m, MOI.ConstraintSet(), CI)
-        MOI.set!(m, MOI.ConstraintSet(), CI, S(_getrhs(current_set) - replacement.constant))
-    end
+    m.constraint_constant[m[CI]] = replacement.constant
+    nothing
 end
 
 #=

--- a/src/constraints/scalaraffine.jl
+++ b/src/constraints/scalaraffine.jl
@@ -196,23 +196,23 @@ function MOI.modify!(model::LinQuadOptimizer, index::LCI{S}, change::MOI.ScalarC
     change_matrix_coefficient!(model, row, column, change.new_coefficient)
 end
 
-MOI.canset(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{LCI{S}}) where {S <: Union{LE, GE, EQ}} = true
-function MOI.set!(m::LinQuadOptimizer, attr::MOI.ConstraintFunction, CI::LCI{S}, replacement::Linear) where {S <: Union{LE, GE, EQ}}
-    previous = MOI.get(m, attr, CI)
-    for term in previous.terms
-        var = term.variable_index
-        chg = MOI.ScalarCoefficientChange{Float64}(var, zero(Float64))
-        MOI.modify!(m, CI, chg)
-    end
-    for term in replacement.terms
-        var = term.variable_index
-        chg = MOI.ScalarCoefficientChange{Float64}(var, term.coefficient)
-        MOI.modify!(m, CI, chg)
-    end
-    change_rhs_coefficient!(m, m[CI], -replacement.constant)
-    m.constraint_constant[m[CI]] = replacement.constant
-    nothing
-end
+# MOI.canset(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{LCI{S}}) where {S <: Union{LE, GE, EQ}} = true
+# function MOI.set!(m::LinQuadOptimizer, attr::MOI.ConstraintFunction, CI::LCI{S}, replacement::Linear) where {S <: Union{LE, GE, EQ}}
+#     previous = MOI.get(m, attr, CI)
+#     for term in previous.terms
+#         var = term.variable_index
+#         chg = MOI.ScalarCoefficientChange{Float64}(var, zero(Float64))
+#         MOI.modify!(m, CI, chg)
+#     end
+#     for term in replacement.terms
+#         var = term.variable_index
+#         chg = MOI.ScalarCoefficientChange{Float64}(var, term.coefficient)
+#         MOI.modify!(m, CI, chg)
+#     end
+#     change_rhs_coefficient!(m, m[CI], get_rhs(m, m[CI]) - replacement.constant)
+#     m.constraint_constant[m[CI]] = replacement.constant
+#     nothing
+# end
 
 #=
     Change RHS of linear constraint without modifying sense

--- a/src/constraints/scalaraffine.jl
+++ b/src/constraints/scalaraffine.jl
@@ -183,7 +183,7 @@ function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintFunction, index::LCI{<
         model.variable_references[columns],
         coefficients
     )
-    Linear(terms, -model.constraint_constant[row])
+    Linear(terms, model.constraint_constant[row])
 end
 
 #=

--- a/src/constraints/scalaraffine.jl
+++ b/src/constraints/scalaraffine.jl
@@ -233,8 +233,6 @@ function MOI.set!(model::LinQuadOptimizer, attr::MOI.ConstraintFunction, CI::LCI
     else
         _replace_with_different_sparsity!(model, previous, replacement, row)
     end
-    @show get_rhs(model, row)
-    @show (replacement.constant - previous.constant)
     change_rhs_coefficient!(model, row, get_rhs(model, row) - (replacement.constant - previous.constant))
     model.constraint_constant[model[CI]] = replacement.constant
     nothing

--- a/src/constraints/scalaraffine.jl
+++ b/src/constraints/scalaraffine.jl
@@ -209,6 +209,7 @@ function MOI.set!(m::LinQuadOptimizer, attr::MOI.ConstraintFunction, CI::LCI{S},
         chg = MOI.ScalarCoefficientChange{Float64}(var, term.coefficient)
         MOI.modify!(m, CI, chg)
     end
+    change_rhs_coefficient!(m, m[CI], -replacement.constant)
     m.constraint_constant[m[CI]] = replacement.constant
     nothing
 end

--- a/src/constraints/scalaraffine.jl
+++ b/src/constraints/scalaraffine.jl
@@ -209,6 +209,10 @@ function MOI.set!(m::LinQuadOptimizer, attr::MOI.ConstraintFunction, CI::LCI{S},
         chg = MOI.ScalarCoefficientChange{Float64}(var, term.coefficient)
         MOI.modify!(m, CI, chg)
     end
+    if !iszero(previous.constant) || !iszero(replacement.constant)
+        current_set = MOI.get(m, MOI.ConstraintSet(), CI)
+        MOI.set!(m, MOI.ConstraintSet(), CI, S(_getrhs(current_set) + previous.constant - replacement.constant))
+    end
 end
 
 #=

--- a/src/constraints/scalaraffine.jl
+++ b/src/constraints/scalaraffine.jl
@@ -211,7 +211,7 @@ function MOI.set!(m::LinQuadOptimizer, attr::MOI.ConstraintFunction, CI::LCI{S},
     end
     if !iszero(previous.constant) || !iszero(replacement.constant)
         current_set = MOI.get(m, MOI.ConstraintSet(), CI)
-        MOI.set!(m, MOI.ConstraintSet(), CI, S(_getrhs(current_set) + previous.constant - replacement.constant))
+        MOI.set!(m, MOI.ConstraintSet(), CI, S(_getrhs(current_set) - replacement.constant))
     end
 end
 

--- a/src/constraints/scalaraffine.jl
+++ b/src/constraints/scalaraffine.jl
@@ -196,6 +196,21 @@ function MOI.modify!(model::LinQuadOptimizer, index::LCI{S}, change::MOI.ScalarC
     change_matrix_coefficient!(model, row, column, change.new_coefficient)
 end
 
+MOI.canset(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{LCI{S}}) where {S <: Union{LE, GE, EQ}} = true
+function MOI.set!(m::LinQuadOptimizer, attr::MOI.ConstraintFunction, CI::LCI{S}, replacement::Linear) where {S <: Union{LE, GE, EQ}}
+    previous = MOI.get(m, attr, CI)
+    for term in previous.terms
+        var = term.variable_index
+        chg = MOI.ScalarCoefficientChange{Float64}(var, zero(Float64))
+        MOI.modify!(m, CI, chg)
+    end
+    for term in replacement.terms
+        var = term.variable_index
+        chg = MOI.ScalarCoefficientChange{Float64}(var, term.coefficient)
+        MOI.modify!(m, CI, chg)
+    end
+end
+
 #=
     Change RHS of linear constraint without modifying sense
 =#

--- a/src/constraints/scalaraffine.jl
+++ b/src/constraints/scalaraffine.jl
@@ -233,7 +233,9 @@ function MOI.set!(model::LinQuadOptimizer, attr::MOI.ConstraintFunction, CI::LCI
     else
         _replace_with_different_sparsity!(model, previous, replacement, row)
     end
-    change_rhs_coefficient!(model, row, replacement.constant - previous.constant)
+    @show get_rhs(model, row)
+    @show (replacement.constant - previous.constant)
+    change_rhs_coefficient!(model, row, get_rhs(model, row) - (replacement.constant - previous.constant))
     model.constraint_constant[model[CI]] = replacement.constant
     nothing
 end

--- a/src/constraints/scalaraffine.jl
+++ b/src/constraints/scalaraffine.jl
@@ -202,12 +202,16 @@ end
 MOI.supports(::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{LCI{S}}) where S <: LinSets = true
 function MOI.set!(model::LinQuadOptimizer, ::MOI.ConstraintSet, index::LCI{S},
                   new_set::S) where S <: Union{LE, GE, EQ}
-    change_rhs_coefficient!(model, model[index], MOIU.getconstant(new_set))
+    row = model[index]
+    rhs = MOIU.getconstant(new_set) - model.constraint_constant[row]
+    change_rhs_coefficient!(model, model[index], rhs)
 end
 
 function MOI.set!(model::LinQuadOptimizer, ::MOI.ConstraintSet, index::LCI{IV},
                   new_set::IV)
-    modify_ranged_constraints!(model, [model[index]], [new_set.lower], [new_set.upper])
+    row = model[index]
+    constant = model.constraint_constant[row]
+    modify_ranged_constraints!(model, [model[index]], [new_set.lower - constant], [new_set.upper - constant])
 end
 
 #=

--- a/src/constraints/vectoraffine.jl
+++ b/src/constraints/vectoraffine.jl
@@ -78,7 +78,6 @@ end
 
 function MOI.set!(m::LinQuadOptimizer, attr::MOI.ConstraintFunction, c::VLCI{S}, replacement::VecLin) where {S <: VecLinSets}
     constraint_indices = m[c]
-    @assert length(constraint_indices) == length(replacement.terms) == length(replacement.constants)
     previous = MOI.get(m, attr, c)
     for term in previous.terms
         row = constraint_indices[term.output_index]

--- a/src/constraints/vectoraffine.jl
+++ b/src/constraints/vectoraffine.jl
@@ -92,9 +92,7 @@ function MOI.set!(m::LinQuadOptimizer, attr::MOI.ConstraintFunction, c::VLCI{S},
     end
     for i in eachindex(constraint_indices)
         row = constraint_indices[i]
-        if !iszero(previous.constants[i]) || !iszero(replacement.constants[i])
-            m.constraint_constant[row] = replacement.constants[i]
-        end
+        m.constraint_constant[row] = replacement.constants[i]
     end
 end
 

--- a/src/constraints/vectoraffine.jl
+++ b/src/constraints/vectoraffine.jl
@@ -91,6 +91,7 @@ function MOI.set!(m::LinQuadOptimizer, attr::MOI.ConstraintFunction, c::VLCI{S},
     end
     for i in eachindex(constraint_indices)
         row = constraint_indices[i]
+        change_rhs_coefficient!(m, row, -replacement.constants[i])
         m.constraint_constant[row] = replacement.constants[i]
     end
 end

--- a/src/constraints/vectoraffine.jl
+++ b/src/constraints/vectoraffine.jl
@@ -89,8 +89,8 @@ w.r.t. their constraint rows and columns. Assumes both functions are already
 in canonical form.
 """
 function _matching_sparsity_pattern(f1::T, f2::T) where {T <: Union{Linear, VecLin}}
-    indices(f1.terms) == indices(f2.terms) || return false
-    indices(_constant(f1)) == indices(_constant(f2)) || return false
+    Compat.axes(f1.terms) == Compat.axes(f2.terms) || return false
+    Compat.axes(_constant(f1)) == Compat.axes(_constant(f2)) || return false
     for i in eachindex(f1.terms)
         MOIU.termindices(f1.terms[i]) == MOIU.termindices(f2.terms[i]) || return false
     end

--- a/src/constraints/vectoraffine.jl
+++ b/src/constraints/vectoraffine.jl
@@ -128,6 +128,7 @@ function MOI.set!(model::LinQuadOptimizer, attr::MOI.ConstraintFunction, c::VLCI
     for i in eachindex(constraint_indices)
         row = constraint_indices[i]
         model.constraint_constant[row] = replacement.constants[i]
+        change_rhs_coefficient!(model, row, -replacement.constants[i])
     end
 end
 

--- a/src/solver_interface.jl
+++ b/src/solver_interface.jl
@@ -205,6 +205,24 @@ Set the linear coefficient of the variable in column `col`, constraint `row` to
 function change_matrix_coefficient! end
 
 """
+    change_matrix_coefficients!(m, rows, cols, coefs)
+
+Change multiple linear coefficients simultaneously. Sets the linear coefficient
+of the variable at column `cols[i]` in constraint `rows[i]` to `coefs[i]` for
+`i in 1:length(rows)`. Requires that `length(rows) == length(cols) == length(coefs)`.
+
+By default, this method just calls
+`change_matrix_coefficient!(m, rows[i], cols[i], coefs[i])` repeatedly, but
+some solver interfaces may offer more efficient implementations.
+"""
+function change_matrix_coefficients!(m, rows, cols, coefs)
+    @boundscheck((indices(rows) == indices(cols) == indices(coefs)) || throw(DimensionMismatch()))
+    for i in eachindex(rows)
+        change_matrix_coefficient!(m, rows[i], cols[i], coefs[i])
+    end
+end
+
+"""
 change_objective_coefficient!(m, col, coef)
 
 Set the linear coefficient of the variable in column `col` to `coef` in the objective function.

--- a/src/solver_interface.jl
+++ b/src/solver_interface.jl
@@ -216,7 +216,7 @@ By default, this method just calls
 some solver interfaces may offer more efficient implementations.
 """
 function change_matrix_coefficients!(m, rows, cols, coefs)
-    @boundscheck((indices(rows) == indices(cols) == indices(coefs)) || throw(DimensionMismatch()))
+    @boundscheck((Compat.axes(rows) == Compat.axes(cols) == Compat.axes(coefs)) || throw(DimensionMismatch()))
     for i in eachindex(rows)
         change_matrix_coefficient!(m, rows[i], cols[i], coefs[i])
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -118,6 +118,21 @@ end
 end
 
 @testset "Issue #32" begin
+    check_set(actual::MOI.GreaterThan, expected::MOI.GreaterThan) =
+        @test actual.lower == expected.lower
+    check_set(actual::MOI.LessThan, expected::MOI.LessThan) =
+        @test actual.upper == expected.upper
+    function check_set(actual::MOI.Interval, expected::MOI.Interval)
+        @test actual.lower == expected.lower
+        @test actual.lower == expected.lower
+    end
+    function check_row(model, constraint_index, expected_function, expected_set)
+        actual_function = MOI.get(model, MOI.ConstraintFunction(), constraint_index)
+        @test actual_function ≈ expected_function
+        actual_set = MOI.get(model, MOI.ConstraintSet(), constraint_index)
+        check_set(actual_set, expected_set)
+    end
+
     @testset "Simple scalar affine function replacement" begin
         model = LQOI.MockLinQuadOptimizer()
         x = MOI.addvariable!(model)
@@ -126,46 +141,30 @@ end
         f =  MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0], [x]), 0.1)
         s = MOI.GreaterThan(0.5)
         c = MOI.addconstraint!(model, f, s)
-        @test MOI.get(model, MOI.ConstraintFunction(), c) ≈ f
-        s2 = MOI.get(model, MOI.ConstraintSet(), c)
-        @test typeof(s2) == typeof(s)
-        @test s2.lower == s.lower
+        check_row(model, c, f, s)
 
         # Replace the constraint function with itself and verify that
         # the problem is unchanged
         MOI.set!(model, MOI.ConstraintFunction(), c, f)
-        @test MOI.get(model, MOI.ConstraintFunction(), c) ≈ f
-        s2 = MOI.get(model, MOI.ConstraintSet(), c)
-        @test typeof(s2) == typeof(s)
-        @test s2.lower == s.lower
+        check_row(model, c, f, s)
 
         # Replace the constraint function with a new function, verify
         # that the replacement occurred and that the set is unchanged
         f2 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 0.5)
         MOI.set!(model, MOI.ConstraintFunction(), c, f2)
-        @test MOI.get(model, MOI.ConstraintFunction(), c) ≈ f2
-        s2 = MOI.get(model, MOI.ConstraintSet(), c)
-        @test typeof(s2) == typeof(s)
-        @test s2.lower == s.lower
+        check_row(model, c, f2, s)
 
         # Replace the constraint function with a new function which is not
         # in canonical form:
         f3 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 0.5], [x]), 0.5)
         MOI.set!(model, MOI.ConstraintFunction(), c, f3)
-        @test MOI.get(model, MOI.ConstraintFunction(), c) ≈ MOIU.canonical(f3)
-        s2 = MOI.get(model, MOI.ConstraintSet(), c)
-        @test typeof(s2) == typeof(s)
-        @test s2.lower == s.lower
-
+        check_row(model, c, MOIU.canonical(f3), s)
 
         # Replace the constraint function with a new function whose sparsity
         # pattern is different:
         f4 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{Float64}[], 2.0)
         MOI.set!(model, MOI.ConstraintFunction(), c, f4)
-        @test MOI.get(model, MOI.ConstraintFunction(), c) ≈ f4
-        s2 = MOI.get(model, MOI.ConstraintSet(), c)
-        @test typeof(s2) == typeof(s)
-        @test s2.lower == s.lower
+        check_row(model, c, f4, s)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,3 +55,16 @@ const LQOI = LinQuadOptInterface
         end
     end
 end
+
+@testset "Issue #52" begin
+    model = LQOI.MockLinQuadOptimizer()
+    x = MOI.addvariable!(model)
+    f1 =  MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 1.5)
+    s1 = MOI.LessThan(2.0)
+    c = MOI.addconstraint!(model, f1, s1)
+    f2 = MOI.get(model, MOI.ConstraintFunction(), c)
+    @test f1 ≈ f2
+    s2 = MOI.get(model, MOI.ConstraintSet(), c)
+    @test typeof(s1) == typeof(s2)
+    @test s1.upper == s2.upper
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,7 +107,7 @@ end
         c = MOI.addconstraint!(model, f, s)
         # Change the constraint set, and verify that we get the same set
         # when we retrieve it:
-        s2 = MOI.LessThan(1.0)
+        s2 = MOI.Interval(1.0, 2.0)
         MOI.set!(model, MOI.ConstraintSet(), c, s2)
         s3 = MOI.get(model, MOI.ConstraintSet(), c)
         @test typeof(s2) == typeof(s3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -126,6 +126,10 @@ end
         @test actual.lower == expected.lower
         @test actual.lower == expected.lower
     end
+    function check_set(actual::S, expected::S) where {S <: Union{MOI.Nonnegatives, MOI.Nonpositives, MOI.Zeros}}
+        @test actual.dimension == expected.dimension
+    end
+
     function check_row(model, constraint_index, expected_function, expected_set)
         actual_function = MOI.get(model, MOI.ConstraintFunction(), constraint_index)
         @test actual_function ≈ expected_function
@@ -133,13 +137,89 @@ end
         check_set(actual_set, expected_set)
     end
 
-    @testset "Simple scalar affine function replacement" begin
+    @testset "Scalar affine function" begin
+        @testset "Single variable" begin
+            model = LQOI.MockLinQuadOptimizer()
+            x = MOI.addvariable!(model)
+
+            # Add the constraint and verify that we can retrieve it
+            f =  MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0], [x]), 0.1)
+            s = MOI.GreaterThan(0.5)
+            c = MOI.addconstraint!(model, f, s)
+            check_row(model, c, f, s)
+
+            # Replace the constraint function with itself and verify that
+            # the problem is unchanged
+            MOI.set!(model, MOI.ConstraintFunction(), c, f)
+            check_row(model, c, f, s)
+
+            # Replace the constraint function with a new function, verify
+            # that the replacement occurred and that the set is unchanged
+            f2 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 0.5)
+            MOI.set!(model, MOI.ConstraintFunction(), c, f2)
+            check_row(model, c, f2, s)
+
+            # Replace the constraint function with a new function which is not
+            # in canonical form:
+            f3 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 0.5], [x]), 0.5)
+            MOI.set!(model, MOI.ConstraintFunction(), c, f3)
+            check_row(model, c, MOIU.canonical(f3), s)
+
+            # Replace the constraint function with a new function whose sparsity
+            # pattern is different:
+            f4 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{Float64}[], 2.0)
+            MOI.set!(model, MOI.ConstraintFunction(), c, f4)
+            check_row(model, c, f4, s)
+        end
+
+        @testset "Multiple variables" begin
+            model = LQOI.MockLinQuadOptimizer()
+            x = MOI.addvariable!(model)
+            y = MOI.addvariable!(model)
+
+            # Add the constraint and verify that we can retrieve it
+            f =  MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 2.0], [x, y]), 0.1)
+            s = MOI.GreaterThan(0.5)
+            c = MOI.addconstraint!(model, f, s)
+            check_row(model, c, f, s)
+
+            # Replace the constraint function with itself and verify that
+            # the problem is unchanged
+            MOI.set!(model, MOI.ConstraintFunction(), c, f)
+            check_row(model, c, f, s)
+
+            # Replace the constraint function with a new function, verify
+            # that the replacement occurred and that the set is unchanged
+            f2 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([0.5, 1.0], [x, y]), 0.5)
+            MOI.set!(model, MOI.ConstraintFunction(), c, f2)
+            check_row(model, c, f2, s)
+
+            # Replace the constraint function with a new function which is not
+            # in canonical form:
+            f3 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([-0.1, 0.2], [y, x]), 0.5)
+            MOI.set!(model, MOI.ConstraintFunction(), c, f3)
+            check_row(model, c, MOIU.canonical(f3), s)
+
+            # Replace the constraint function with a new function whose sparsity
+            # pattern is different:
+            f4 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([-2.0], [y]), 2.0)
+            MOI.set!(model, MOI.ConstraintFunction(), c, f4)
+            check_row(model, c, f4, s)
+        end
+    end
+
+    @testset "Vector affine function" begin
         model = LQOI.MockLinQuadOptimizer()
         x = MOI.addvariable!(model)
+        y = MOI.addvariable!(model)
 
         # Add the constraint and verify that we can retrieve it
-        f =  MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0], [x]), 0.1)
-        s = MOI.GreaterThan(0.5)
+        f = MOI.VectorAffineFunction(
+            [MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x)),
+             MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(2.0, y)),
+             MOI.VectorAffineTerm(2, MOI.ScalarAffineTerm(-1.0, x))],
+            [0.1, 0.2])
+        s = MOI.Nonpositives(2)
         c = MOI.addconstraint!(model, f, s)
         check_row(model, c, f, s)
 
@@ -148,26 +228,34 @@ end
         MOI.set!(model, MOI.ConstraintFunction(), c, f)
         check_row(model, c, f, s)
 
+
         # Replace the constraint function with a new function, verify
         # that the replacement occurred and that the set is unchanged
-        f2 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 0.5)
+        f2 = MOI.VectorAffineFunction(
+            [MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(3.0, x)),
+             MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(-2.0, y)),
+             MOI.VectorAffineTerm(2, MOI.ScalarAffineTerm(-1.5, x))],
+            [0.5, 2.0])
         MOI.set!(model, MOI.ConstraintFunction(), c, f2)
         check_row(model, c, f2, s)
 
         # Replace the constraint function with a new function which is not
         # in canonical form:
-        f3 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 0.5], [x]), 0.5)
+        f3 = MOI.VectorAffineFunction(
+            [MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(2.0, x)),
+             MOI.VectorAffineTerm(2, MOI.ScalarAffineTerm(-1.5, x)),
+             MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(-2.5, y))],
+            [0.1, 0.2])
         MOI.set!(model, MOI.ConstraintFunction(), c, f3)
         check_row(model, c, MOIU.canonical(f3), s)
 
         # Replace the constraint function with a new function whose sparsity
         # pattern is different:
-        f4 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{Float64}[], 2.0)
+        f4 = MOI.VectorAffineFunction(
+            [MOI.VectorAffineTerm(2, MOI.ScalarAffineTerm(-1.5, y)),
+             MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(2.0, x))],
+            [0.1, 0.2])
         MOI.set!(model, MOI.ConstraintFunction(), c, f4)
         check_row(model, c, f4, s)
     end
 end
-
-
-
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,7 +75,7 @@ end
         f1 =  MOI.VectorAffineFunction(
             MOI.VectorAffineTerm.([1], MOI.ScalarAffineTerm.([1.0], [x])), [1.5])
         s1 = MOI.Zeros(1)
-        c = MOI.addconstraint!(model, f1, s)
+        c = MOI.addconstraint!(model, f1, s1)
         f2 = MOI.get(model, MOI.ConstraintFunction(), c)
         @test f1 ≈ f2
         s2 = MOI.get(model, MOI.ConstraintSet(), c)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,14 +57,61 @@ const LQOI = LinQuadOptInterface
 end
 
 @testset "Issue #52" begin
-    model = LQOI.MockLinQuadOptimizer()
-    x = MOI.addvariable!(model)
-    f1 =  MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 1.5)
-    s1 = MOI.LessThan(2.0)
-    c = MOI.addconstraint!(model, f1, s1)
-    f2 = MOI.get(model, MOI.ConstraintFunction(), c)
-    @test f1 ≈ f2
-    s2 = MOI.get(model, MOI.ConstraintSet(), c)
-    @test typeof(s1) == typeof(s2)
-    @test s1.upper == s2.upper
+    @testset "scalaraffine" begin
+        model = LQOI.MockLinQuadOptimizer()
+        x = MOI.addvariable!(model)
+        f1 =  MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 1.5)
+        s1 = MOI.LessThan(2.0)
+        c = MOI.addconstraint!(model, f1, s1)
+        f2 = MOI.get(model, MOI.ConstraintFunction(), c)
+        @test f1 ≈ f2
+        s2 = MOI.get(model, MOI.ConstraintSet(), c)
+        @test typeof(s1) == typeof(s2)
+        @test s1.upper == s2.upper
+    end
+    @testset "vectoraffine" begin
+        model = LQOI.MockLinQuadOptimizer()
+        x = MOI.addvariable!(model)
+        f1 =  MOI.VectorAffineFunction(
+            MOI.VectorAffineTerm.([1], MOI.ScalarAffineTerm.([1.0], [x])), [1.5])
+        s1 = MOI.Zeros(1)
+        c = MOI.addconstraint!(model, f, s)
+        f2 = MOI.get(model, MOI.ConstraintFunction(), c)
+        @test f1 ≈ f2
+        s2 = MOI.get(model, MOI.ConstraintSet(), c)
+        @test typeof(s1) == typeof(s2)
+        @test s1.dimension == s2.dimension
+    end
+end
+
+@testset "Issue #54" begin
+    @testset "scalar, one-sided" begin
+        model = LQOI.MockLinQuadOptimizer()
+        x = MOI.addvariable!(model)
+        f =  MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 1.5)
+        s = MOI.LessThan(2.0)
+        c = MOI.addconstraint!(model, f, s)
+        # Change the constraint set, and verify that we get the same set
+        # when we retrieve it:
+        s2 = MOI.LessThan(1.0)
+        MOI.set!(model, MOI.ConstraintSet(), c, s2)
+        s3 = MOI.get(model, MOI.ConstraintSet(), c)
+        @test typeof(s2) == typeof(s3)
+        @test s2.upper == s3.upper
+    end
+    @testset "scalar, interval" begin
+        model = LQOI.MockLinQuadOptimizer()
+        x = MOI.addvariable!(model)
+        f =  MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 1.5)
+        s = MOI.Interval(2.0, 3.0)
+        c = MOI.addconstraint!(model, f, s)
+        # Change the constraint set, and verify that we get the same set
+        # when we retrieve it:
+        s2 = MOI.LessThan(1.0)
+        MOI.set!(model, MOI.ConstraintSet(), c, s2)
+        s3 = MOI.get(model, MOI.ConstraintSet(), c)
+        @test typeof(s2) == typeof(s3)
+        @test s2.lower == s3.lower
+        @test s2.upper == s3.upper
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,7 +75,7 @@ end
         f1 =  MOI.VectorAffineFunction(
             MOI.VectorAffineTerm.([1], MOI.ScalarAffineTerm.([1.0], [x])), [1.5])
         s1 = MOI.Zeros(1)
-        c = MOI.addconstraint!(model, f, s)
+        c = MOI.addconstraint!(model, f1, s)
         f2 = MOI.get(model, MOI.ConstraintFunction(), c)
         @test f1 ≈ f2
         s2 = MOI.get(model, MOI.ConstraintSet(), c)


### PR DESCRIPTION
Fixes #32 
Fixes https://github.com/JuliaOpt/GLPK.jl/issues/58

I'm not sure how to test this. There's a `solve_func_scalaraffine_lessthan` modification unit test in MOI.Test, but it doesn't seem to be run during the LQOI tests. I'd appreciate some help turning that on (and any other tests that are available). 