### PR TITLE
make it possible to set the type of the inner model

### DIFF
--- a/src/LinQuadOptInterface.jl
+++ b/src/LinQuadOptInterface.jl
@@ -199,14 +199,6 @@ function Base.isempty(map::ConstraintMapping)
     return ret
 end
 
-macro def(name, definition)
-    return quote
-        macro $(esc(name))()
-            esc($(Expr(:quote, definition)))
-        end
-    end
-end
-
 @enum(ObjectiveType,
       SingleVariableObjective,
       AffineObjective,
@@ -214,9 +206,10 @@ end
 
 # Abstract + macro
 abstract type LinQuadOptimizer <: MOI.AbstractOptimizer end
-@def LinQuadOptimizerBase begin
 
-    inner#::LinQuadOptInterface.LinQuadOptimizer
+macro LinQuadOptimizerBase(inner_model_type=Any)
+    esc(quote
+    inner::$inner_model_type
 
     name::String
 
@@ -256,7 +249,9 @@ abstract type LinQuadOptimizer <: MOI.AbstractOptimizer end
     dual_result_count::Int
 
     solvetime::Float64
+    end)
 end
+
 
 function MOI.isempty(m::LinQuadOptimizer)
 


### PR DESCRIPTION
fixes #38 

Since we were using `@def` in exactly one place, it was easier just to get rid of it and implement the `LinQuadOptimizerBase` macro directly. Doing so made it simple to add an optional `inner_model_type` argument which provides a type for the `inner` field. 

This should be totally backwards compatible, as all existing usages of `@LinQuadOptimizerBase` will still work. But once this is merged we can update the usage in the solver wrappers to `@LinQuadOptimizerBase(Gurobi.Model)` etc. 