### PR TITLE
Remove Nullables dependency

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 julia 0.6
 MathOptInterface 0.4 0.5
-Nullables
 Compat 0.59

--- a/src/LinQuadOptInterface.jl
+++ b/src/LinQuadOptInterface.jl
@@ -1,14 +1,6 @@
-#=
- TODOs:
-
-    - get quadratic objective functions
-
-=#
-
 __precompile__()
 module LinQuadOptInterface
 
-using Nullables
 using Compat
 using Compat.SparseArrays
 
@@ -214,7 +206,7 @@ macro LinQuadOptimizerBase(inner_model_type=Any)
     name::String
 
     obj_type::LinQuadOptInterface.ObjectiveType
-    single_obj_var::Nullable{MOI.VariableIndex}
+    single_obj_var::Union{Nothing, MOI.VariableIndex}
     obj_sense::MOI.OptimizationSense
 
     last_variable_reference::UInt64
@@ -254,11 +246,10 @@ end
 
 
 function MOI.isempty(m::LinQuadOptimizer)
-
     ret = true
     ret = ret && m.name == ""
     ret = ret && m.obj_type == AffineObjective
-    ret = ret && isnull(m.single_obj_var)
+    ret = ret && isa(m.single_obj_var, Nothing)
     ret = ret && m.obj_sense == MOI.MinSense
     ret = ret && m.last_variable_reference == 0
     ret = ret && isempty(m.variable_mapping)

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -97,7 +97,7 @@ end
 
 MOI.canget(m::LinQuadOptimizer, ::MOI.ObjectiveFunction{MOI.SingleVariable}) = m.obj_type == SingleVariableObjective
 function MOI.get(m::LinQuadOptimizer, ::MOI.ObjectiveFunction{MOI.SingleVariable})
-    SingleVariable(get(m.single_obj_var))
+    SingleVariable(m.single_obj_var::MOI.VariableIndex)
 end
 
 MOI.canget(m::LinQuadOptimizer, ::MOI.ObjectiveFunction{Linear}) = m.obj_type != QuadraticObjective


### PR DESCRIPTION
It turns out the only place we use `single_obj_var` was when getting the `ObjectiveFunction{SingleVariable}`.

Closes #42