### PR TITLE
RFC: updates for MOI 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,21 +27,10 @@ notifications:
     on_failure: always  # options: [always|never|change] default: always
     on_start: never     # options: [always|never|change] default: always
 
-## uncomment and modify the following lines to manually install system packages
-#addons:
-#  apt: # apt-get for linux
-#    packages:
-#    - gfortran
-#before_script: # homebrew for mac
-#  - if [ $TRAVIS_OS_NAME = osx ]; then brew install gcc; fi
-
-## uncomment the following lines to override the default test script
 script:
-  - julia -e 'Pkg.clone(pwd()); Pkg.build("LinQuadOptInterface"); Pkg.test("LinQuadOptInterface"; coverage=true)'
+  - julia -e 'Pkg.clone(pwd()); Pkg.build("LinQuadOptInterface")'
+  - julia -e 'Pkg.test("LinQuadOptInterface"; coverage=true)'
 after_success:
-  # push coverage results to Coveralls
-  #- julia -e 'cd(Pkg.dir("LinQuadOptInterface")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
-  # push coverage results to Codecov
   - julia -e 'cd(Pkg.dir("LinQuadOptInterface")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
   #- julia -e 'Pkg.add("Documenter")'
   #- julia -e 'cd(Pkg.dir("LinQuadOptInterface")); include(joinpath("docs", "make.jl"))'

--- a/README.md
+++ b/README.md
@@ -13,35 +13,24 @@
 [gitter-img]: https://badges.gitter.im/JuliaOpt/JuMP-dev.svg
 [discourse-url]: https://discourse.julialang.org/c/domain/opt
 
-LinQuadOptInterface.jl (LQOI) is designed to simplify [MathOptInterface.jl](https://github.com/JuliaOpt/MathOptInterface.jl)'s (MOI) implementation for some solvers. The target use cases are low-level wrappers designed to bridge low-level Integer Linear and Quadratic solvers, for instance [GLPK.jl](https://github.com/JuliaOpt/GLPK.jl), [Gurobi.jl](https://github.com/JuliaOpt/Gurobi.jl), [Xpress.jl](https://github.com/JuliaOpt/Xpress.jl) and [CPLEX.jl](https://github.com/JuliaOpt/CPLEX.jl).
+LinQuadOptInterface.jl (LQOI) is designed to provide an intermediate interface
+to [MathOptInterface.jl](https://github.com/JuliaOpt/MathOptInterface.jl)
+for some solvers. The target use-cases are low-level wrappers designed to bridge
+low-level mixed integer linear and quadratic solvers.
 
-The use of LQOI for MOI implementations is entirely optional. Using LQOI introduces an extra abstraction layer between a solver and MOI. Its recommended to carefully analyse if the solver's low-level API is close to what LQOI expects, otherwise a direct implementation of MOI might be a better option.
+Examples of packages currently using LQOI include [Clp.jl](https://github.com/JuliaOpt/Clp.jl),
+[GLPK.jl](https://github.com/JuliaOpt/GLPK.jl), [Gurobi.jl](https://github.com/JuliaOpt/Gurobi.jl), and [Xpress.jl](https://github.com/JuliaOpt/Xpress.jl).
 
-## <a name="modifications"></a> Problem Modifications
+The interface is documented [here](https://github.com/JuliaOpt/LinQuadOptInterface.jl/blob/master/src/solver_interface.jl).
 
-LQOI provides access to many MOI functionalities mainly related to problem modifications:
+## Note to solver developers
 
-1. add constraints/variables 1-by-1 and in batches
-2. remove constraints/variables
-3. change constraint coefficients
-4. change constraint type
-5. change constraint rhs
-6. change variable bounds and type
+The use of LQOI for MOI wrappers of low-level solvers is entirely optional.
+Using LQOI introduces an extra abstraction layer between a solver and MOI. We
+recommend that you carefully analyze the solver's low-level API to check if it
+is close to what LQOI expects.
 
-## LinQuadOptimizer
-
-In LinQuadOptInterface.jl the MOI [`AbstractOptimizer`](http://www.juliaopt.org/MathOptInterface.jl/latest/apireference.html#MathOptInterface.AbstractOptimizer) is specialized to [`LinQuadOptimizer`](https://github.com/JuliaOpt/LinQuadOptInterface.jl/blob/99b2a3dfe78e000330475f08766f6681ecf633ab/src/LinQuadOptInterface.jl#L131). In this implementation all the above mentioned [modifications](#modifications) are carried out by the low-level solver's own functionalities and hence the `LinQuadOptimizer` can be used without a [`CachingOptimizer`](https://github.com/JuliaOpt/MathOptInterface.jl/blob/60c5ee85addb65ada33cb1d922691f23e5a518e2/src/Utilities/cachingoptimizer.jl#L8). The latter will keep all problem data in the Julia level and typically push to a low-level solver the complete problem at once.
-
-In contrast, since `LinQuadOptimizer` incrementally pushes data to the low-level solver, it stores a small subset of the problem data at the Julia level; typically only references to constraints and variables.
-
-## Current uses
-
-This package is currently used to implement [MathOptInterfaceXpress.jl](https://github.com/JuliaOpt/MathOptInterfaceXpress.jl), [MathOptInterfaceCPLEX.jl](https://github.com/JuliaOpt/MathOptInterfaceCPLEX.jl), [MathOptInterfaceGurobi.jl](https://github.com/JuliaOpt/MathOptInterfaceGurobi.jl) and [MathOptInterfaceGLPK.jl](https://github.com/JuliaOpt/MathOptInterfaceGLPK.jl). The last one being only a mixed integer linear solver.
-
-All these solvers have low-level APIs which support most of the above mentioned [modifications](#modifications). Hence, data storage is simplified and duplications are avoided.
-
-## Other possible uses
-
-This package is only recommended if a solver low-level API which supports most of the above mentioned [modifications](#modifications).
-
-If a solver low-level API does not support most of the above mentioned [modifications](#modifications), then following the example of [MathOptInterfaceSCS.jl](https://github.com/JuliaOpt/MathOptInterfaceSCS.jl) and [MathOptInterfaceECOS.jl](https://github.com/JuliaOpt/MathOptInterfaceECOS.jl) might be a better idea.
+If a solver low-level API does not support most of the functions required by LQOI, then following the example of
+[MathOptInterfaceSCS.jl](https://github.com/JuliaOpt/MathOptInterfaceSCS.jl) and
+[MathOptInterfaceECOS.jl](https://github.com/JuliaOpt/MathOptInterfaceECOS.jl)
+might be a better idea.

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.6
-MathOptInterface 0.4 0.5
+MathOptInterface 0.5 0.6
 Compat 0.59

--- a/src/LinQuadOptInterface.jl
+++ b/src/LinQuadOptInterface.jl
@@ -321,14 +321,15 @@ function MOI.empty!(m::M, env = nothing) where M<:LinQuadOptimizer
     nothing
 end
 
+MOI.canget(::LinQuadOptimizer, ::MOI.Name) = true
 function MOI.get(m::LinQuadOptimizer, ::MOI.Name)
     m.name
 end
-MOI.canget(m::LinQuadOptimizer, ::MOI.Name) = true
+
+MOI.supports(::LinQuadOptimizer, ::MOI.Name) = true
 function MOI.set!(m::LinQuadOptimizer, ::MOI.Name, name::String)
     m.name = name
 end
-MOI.canset(m::LinQuadOptimizer, ::MOI.Name) = true
 
 function MOI.supportsconstraint(m::LinQuadOptimizer, ft::Type{F}, st::Type{S}) where F <: MOI.AbstractFunction where S <: MOI.AbstractSet
     (ft,st) in supported_constraints(m)

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -1,78 +1,66 @@
 #=
     Helper functions to store constraint mappings
 =#
-cmap(m::LinQuadOptimizer) = m.constraint_mapping
+cmap(model::LinQuadOptimizer) = model.constraint_mapping
 # dummy method for isvalid
-constrdict(m::LinQuadOptimizer, ref) = false
+constrdict(::LinQuadOptimizer, ::CI{F, S}) where {F, S} = Dict{CI{F, S}, Any}()
 
-_getrhs(set::LE) = set.upper
-_getrhs(set::GE) = set.lower
-_getrhs(set::EQ) = set.value
-
-function Base.getindex(m::LinQuadOptimizer, c::CI{F,S}) where F where S
-    dict = constrdict(m, c)
-    return dict[c]
+function Base.getindex(model::LinQuadOptimizer, index::CI)
+    return constrdict(model, index)[index]
 end
 
-function deleteconstraintname!(m::LinQuadOptimizer, ref)
-    if haskey(m.constraint_names, ref)
-        name = m.constraint_names[ref]
-        delete!(m.constraint_names_rev, name)
-        delete!(m.constraint_names, ref)
+function delete_constraint_name(model::LinQuadOptimizer, index)
+    if haskey(model.constraint_names, index)
+        name = model.constraint_names[index]
+        delete!(model.constraint_names_rev, name)
+        delete!(model.constraint_names, index)
     end
 end
 
 """
-    hasinteger(m::LinQuadOptimizer)::Bool
+    has_integer(model::LinQuadOptimizer)::Bool
 
-A helper function to determine if the solver instance `m` has any integer
-components (i.e. binary, integer, special ordered sets, semicontinuous, or
-semi-integer variables).
+A helper function to determine if `model` has any integer components (i.e.
+binary, integer, special ordered sets, semicontinuous, or semi-integer
+variables).
 """
-function hasinteger(m::LinQuadOptimizer)
-    (
-        length(cmap(m).integer) +
-        length(cmap(m).binary) +
-        length(cmap(m).sos1) +
-        length(cmap(m).sos2) +
-        length(cmap(m).semicontinuous) +
-        length(cmap(m).semiinteger)
-                ) > 0
+function has_integer(model::LinQuadOptimizer)
+    constraint_map = cmap(model)
+    return length(constraint_map.integer) > 0 ||
+        length(constraint_map.binary) > 0 ||
+        length(constraint_map.sos1) > 0 ||
+        length(constraint_map.sos2) > 0 ||
+        length(constraint_map.semicontinuous) > 0 ||
+        length(constraint_map.semiinteger) > 0
 end
 
 #=
     MOI.isvalid
 =#
 
-function MOI.isvalid(m::LinQuadOptimizer, ref::CI{F,S}) where F where S
-    dict = constrdict(m, ref)
-    if dict == false
-        return false
-    end
-    if haskey(dict, ref)
-        return true
-    end
-    return false
+function MOI.isvalid(model::LinQuadOptimizer, index::CI{F,S}) where F where S
+    dict = constrdict(model, index)
+    return haskey(dict, index)
 end
 
 """
-    _assert_valid(model::LinQuadOptimizer, index::MOI.Index)
+    __assert_valid__(model::LinQuadOptimizer, index::MOI.Index)
 
 Throw an MOI.InvalidIndex error if `MOI.isvalid(model, index) == false`.
 """
-function _assert_valid(model::LinQuadOptimizer, index::MOI.Index)
+function __assert_valid__(model::LinQuadOptimizer, index::MOI.Index)
     if !MOI.isvalid(model, index)
         throw(MOI.InvalidIndex(index))
     end
 end
 
 """
-    _assert_add_constraint(model::LinQuadOptimizer, ::Type{F}, ::Type{S})
+    __assert_supported_constraint__(model::LinQuadOptimizer, ::Type{F}, ::Type{S})
 
 Throw an `UnsupportedConstraint{F, S}` error if the model cannot add constraints
 of type `F`-in-`S`.
 """
-function _assert_add_constraint(model::LinQuadOptimizer, ::Type{F}, ::Type{S}) where {F<:MOI.AbstractFunction, S<:MOI.AbstractSet}
+function __assert_supported_constraint__(model::LinQuadOptimizer, ::Type{F}, ::Type{S}) where {F<:MOI.AbstractFunction, S<:MOI.AbstractSet}
     if !((F,S) in supported_constraints(model))
         throw(MOI.UnsupportedConstraint{F, S}())
     end
@@ -86,10 +74,8 @@ function MOI.canget(model::LinQuadOptimizer, ::MOI.NumberOfConstraints{F, S}) wh
 end
 
 function MOI.get(model::LinQuadOptimizer, attribute::MOI.NumberOfConstraints{F, S}) where F where S
-    if !((F,S) in supported_constraints(model))
-        throw(MOI.UnsupportedAttribute(attribute))
-    end
-    length(constrdict(model, CI{F,S}(UInt(0))))
+    __assert_supported_constraint__(model, F, S)
+    return length(constrdict(model, CI{F,S}(UInt(0))))
 end
 
 #=
@@ -100,10 +86,10 @@ function MOI.canget(model::LinQuadOptimizer, ::MOI.ListOfConstraintIndices{F, S}
 end
 
 function MOI.get(model::LinQuadOptimizer, attribute::MOI.ListOfConstraintIndices{F, S}) where F where S
-    if !((F,S) in supported_constraints(model))
-        throw(MOI.UnsupportedAttribute(attribute))
-    end
-    sort(collect(keys(constrdict(model, CI{F,S}(UInt(0))))), by=x->x.value)
+    __assert_supported_constraint__(model, F, S)
+    dict = constrdict(model, CI{F,S}(UInt(0)))
+    indices = collect(keys(dict))
+    return sort(indices, by=x->x.value)
 end
 
 #=
@@ -112,14 +98,9 @@ end
 function MOI.canget(::LinQuadOptimizer, ::MOI.ListOfConstraints)
     return true
 end
-function MOI.get(m::LinQuadOptimizer, ::MOI.ListOfConstraints)
-    ret = []
-    for (F,S) in supported_constraints(m)
-        if MOI.get(m, MOI.NumberOfConstraints{F,S}()) > 0
-            push!(ret, (F,S))
-        end
-    end
-    ret
+function MOI.get(model::LinQuadOptimizer, ::MOI.ListOfConstraints)
+    return [(F, S) for (F, S) in supported_constraints(model) if
+        MOI.get(model, MOI.NumberOfConstraints{F,S}()) > 0]
 end
 
 #=
@@ -128,28 +109,32 @@ end
 function MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintName, ::Type{<:MOI.ConstraintIndex})
     return true
 end
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintName, c::MOI.ConstraintIndex)
-    if haskey(m.constraint_names, c)
-        m.constraint_names[c]
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintName, index::MOI.ConstraintIndex)
+    if haskey(model.constraint_names, index)
+        return model.constraint_names[index]
     else
-        ""
+        return ""
     end
 end
-MOI.supports(::LinQuadOptimizer, ::MOI.ConstraintName, ::Type{<:MOI.ConstraintIndex}) = true
-function MOI.set!(m::LinQuadOptimizer, ::MOI.ConstraintName, ref::MOI.ConstraintIndex, name::String)
-    if haskey(m.constraint_names_rev, name)
-        if m.constraint_names_rev[name] != ref
+function MOI.supports(::LinQuadOptimizer, ::MOI.ConstraintName, ::Type{<:MOI.ConstraintIndex})
+    return true
+end
+function MOI.set!(model::LinQuadOptimizer, ::MOI.ConstraintName,
+                  index::MOI.ConstraintIndex, name::String)
+    if haskey(model.constraint_names_rev, name)
+        if model.constraint_names_rev[name] != index
             error("Duplicate constraint name: $(name)")
         end
     elseif name != ""
-        if haskey(m.constraint_names, ref)
+        if haskey(model.constraint_names, index)
             # we're renaming an existing constraint
-            old_name = m.constraint_names[ref]
-            delete!(m.constraint_names_rev, old_name)
+            old_name = model.constraint_names[index]
+            delete!(model.constraint_names_rev, old_name)
         end
-        m.constraint_names[ref] = name
-        m.constraint_names_rev[name] = ref
+        model.constraint_names[index] = name
+        model.constraint_names_rev[name] = index
     end
+    return nothing
 end
 
 #=
@@ -157,19 +142,19 @@ end
 =#
 
 # this covers the non-type-stable get(m, ConstraintIndex) case
-function MOI.canget(m::LinQuadOptimizer, ::Type{MOI.ConstraintIndex}, name::String)
-    return haskey(m.constraint_names_rev, name)
+function MOI.canget(model::LinQuadOptimizer, ::Type{MOI.ConstraintIndex}, name::String)
+    return haskey(model.constraint_names_rev, name)
 end
-function MOI.get(m::LinQuadOptimizer, ::Type{<:MOI.ConstraintIndex}, name::String)
-    return m.constraint_names_rev[name]
+function MOI.get(model::LinQuadOptimizer, ::Type{<:MOI.ConstraintIndex}, name::String)
+    return model.constraint_names_rev[name]
 end
 
 # this covers the type-stable get(m, ConstraintIndex{F,S}, name)::CI{F,S} case
 function MOI.canget(model::LinQuadOptimizer, ::Type{FS}, name::String) where FS <: MOI.ConstraintIndex
     return haskey(model.constraint_names_rev, name) && typeof(model.constraint_names_rev[name]) == FS
 end
-function MOI.get(m::LinQuadOptimizer, ::Type{MOI.ConstraintIndex{F,S}}, name::String) where F where S
-    m.constraint_names_rev[name]::MOI.ConstraintIndex{F,S}
+function MOI.get(model::LinQuadOptimizer, ::Type{MOI.ConstraintIndex{F,S}}, name::String) where F where S
+    model.constraint_names_rev[name]::MOI.ConstraintIndex{F,S}
 end
 
 

--- a/src/constraints/scalaraffine.jl
+++ b/src/constraints/scalaraffine.jl
@@ -28,7 +28,7 @@ function addlinearconstraint!(m::LinQuadOptimizer, func::Linear, set::S) where S
 end
 
 function addlinearconstraint!(m::LinQuadOptimizer, func::Linear, set::IV)
-    columns = [getcol(m, term.variable_index) for term in func.terms]
+    columns = [get_column(m, term.variable_index) for term in func.terms]
     coefficients = [term.coefficient for term in func.terms]
     A = CSRMatrix{Float64}([1], columns, coefficients)
     add_ranged_constraints!(m, A, [set.lower], [set.upper])
@@ -38,7 +38,7 @@ function addlinearconstraint!(m::LinQuadOptimizer, func::Linear, sense::Cchar, r
     if abs(func.constant) > eps(Float64)
         Compat.@warn("Constant in scalar function moved into set.")
     end
-    columns = [getcol(m, term.variable_index) for term in func.terms]
+    columns = [get_column(m, term.variable_index) for term in func.terms]
     coefficients = [term.coefficient for term in func.terms]
     A = CSRMatrix{Float64}([1], columns, coefficients)
     add_linear_constraints!(m, A, [sense], [rhs - func.constant])
@@ -94,7 +94,7 @@ function addlinearconstraints!(m::LinQuadOptimizer, func::Vector{Linear}, set::V
     for (fi, f) in enumerate(func)
         row_pointers[fi] = i
         for term in f.terms
-            columns[i] = getcol(m, term.variable_index)
+            columns[i] = get_column(m, term.variable_index)
             coefficients[i] = term.coefficient
             i += 1
         end
@@ -120,7 +120,7 @@ function addlinearconstraints!(m::LinQuadOptimizer, func::Vector{Linear}, sense:
     for (row, f) in enumerate(func)
         row_pointers[row] = i
         for term in f.terms
-            columns[i] = getcol(m, term.variable_index)
+            columns[i] = get_column(m, term.variable_index)
             coefficients[i] = term.coefficient
             i += 1
         end

--- a/src/constraints/scalarquadratic.jl
+++ b/src/constraints/scalarquadratic.jl
@@ -25,7 +25,7 @@ function MOI.addconstraint!(m::LinQuadOptimizer, func::Quad, set::S) where S <: 
 end
 
 function addquadraticconstraint!(m::LinQuadOptimizer, func::Quad, set::S) where S<: Union{LE, GE, EQ}
-    addquadraticconstraint!(m, func, backend_type(m,set), _getrhs(set))
+    addquadraticconstraint!(m, func, backend_type(m,set), MOIU.getconstant(set))
 end
 
 function addquadraticconstraint!(m::LinQuadOptimizer, f::Quad, sense::Cchar, rhs::Float64)
@@ -84,8 +84,8 @@ function reduce_duplicates!(rows::Vector{T}, cols::Vector{T}, vals::Vector{S}) w
 end
 
 function MOI.delete!(m::LinQuadOptimizer, c::QCI{<: LinSets})
-    _assert_valid(m, c)
-    deleteconstraintname!(m, c)
+    __assert_valid__(m, c)
+    delete_constraint_name(m, c)
     dict = constrdict(m, c)
     row = dict[c]
     delete_quadratic_constraints!(m, row, row)

--- a/src/constraints/scalarquadratic.jl
+++ b/src/constraints/scalarquadratic.jl
@@ -83,9 +83,8 @@ function reduce_duplicates!(rows::Vector{T}, cols::Vector{T}, vals::Vector{S}) w
     findnz(sparse(rows, cols, vals))
 end
 
-
-MOI.candelete(m::LinQuadOptimizer, c::QCI{<: LinSets}) = MOI.isvalid(m, c)
 function MOI.delete!(m::LinQuadOptimizer, c::QCI{<: LinSets})
+    _assert_valid(m, c)
     deleteconstraintname!(m, c)
     dict = constrdict(m, c)
     row = dict[c]
@@ -106,7 +105,6 @@ function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::QCI{S}) where S <:
     rhs = get_quadratic_rhs(m, m[c])
     S(rhs)
 end
-
 MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{QCI{IV}}) = false
 
 #=

--- a/src/constraints/scalarquadratic.jl
+++ b/src/constraints/scalarquadratic.jl
@@ -32,15 +32,15 @@ function addquadraticconstraint!(m::LinQuadOptimizer, f::Quad, sense::Cchar, rhs
     if abs(f.constant) > 0
         Compat.@warn("Constant in quadratic function. Moving into set")
     end
-    quadratic_columns_1 = [getcol(m, term.variable_index_1) for term in f.quadratic_terms]
-    quadratic_columns_2 = [getcol(m, term.variable_index_2) for term in f.quadratic_terms]
+    quadratic_columns_1 = [get_column(m, term.variable_index_1) for term in f.quadratic_terms]
+    quadratic_columns_2 = [get_column(m, term.variable_index_2) for term in f.quadratic_terms]
     quadratic_coefficients = [term.coefficient for term in f.quadratic_terms]
     ri, ci, vi = reduce_duplicates!(
         quadratic_columns_1,
         quadratic_columns_2,
         quadratic_coefficients
     )
-    affine_columns = [getcol(m, term.variable_index) for term in f.affine_terms]
+    affine_columns = [get_column(m, term.variable_index) for term in f.affine_terms]
     affine_coefficients = [term.coefficient for term in f.affine_terms]
     add_quadratic_constraint!(m,
         affine_columns,

--- a/src/constraints/scalarquadratic.jl
+++ b/src/constraints/scalarquadratic.jl
@@ -8,48 +8,9 @@
         - constraint functions
         - deleting constraints
 =#
-constrdict(m::LinQuadOptimizer, ::QCI{LE})  = cmap(m).q_less_than
-constrdict(m::LinQuadOptimizer, ::QCI{GE})  = cmap(m).q_greater_than
-constrdict(m::LinQuadOptimizer, ::QCI{EQ})  = cmap(m).q_equal_to
-
-function MOI.addconstraint!(m::LinQuadOptimizer, func::Quad, set::S) where S <: Union{LE, GE, EQ}
-    addquadraticconstraint!(m, func, set)
-    m.last_constraint_reference += 1
-    ref = QCI{S}(m.last_constraint_reference)
-    dict = constrdict(m, ref)
-    push!(m.qconstraint_primal_solution, NaN)
-    push!(m.qconstraint_dual_solution, NaN)
-    dict[ref] = get_number_quadratic_constraints(m)
-    # dict[ref] = length(m.qconstraint_primal_solution)
-    return ref
-end
-
-function addquadraticconstraint!(m::LinQuadOptimizer, func::Quad, set::S) where S<: Union{LE, GE, EQ}
-    addquadraticconstraint!(m, func, backend_type(m,set), MOIU.getconstant(set))
-end
-
-function addquadraticconstraint!(m::LinQuadOptimizer, f::Quad, sense::Cchar, rhs::Float64)
-    if abs(f.constant) > 0
-        Compat.@warn("Constant in quadratic function. Moving into set")
-    end
-    quadratic_columns_1 = [get_column(m, term.variable_index_1) for term in f.quadratic_terms]
-    quadratic_columns_2 = [get_column(m, term.variable_index_2) for term in f.quadratic_terms]
-    quadratic_coefficients = [term.coefficient for term in f.quadratic_terms]
-    ri, ci, vi = reduce_duplicates!(
-        quadratic_columns_1,
-        quadratic_columns_2,
-        quadratic_coefficients
-    )
-    affine_columns = [get_column(m, term.variable_index) for term in f.affine_terms]
-    affine_coefficients = [term.coefficient for term in f.affine_terms]
-    add_quadratic_constraint!(m,
-        affine_columns,
-        affine_coefficients,
-        rhs - f.constant,
-        sense,
-        ri, ci, vi
-    )
-end
+constrdict(model::LinQuadOptimizer, ::QCI{LE})  = cmap(model).q_less_than
+constrdict(model::LinQuadOptimizer, ::QCI{GE})  = cmap(model).q_greater_than
+constrdict(model::LinQuadOptimizer, ::QCI{EQ})  = cmap(model).q_equal_to
 
 """
     reduce_duplicates!(rows::Vector{T}, cols::Vector{T}, vals::Vector{S})
@@ -83,43 +44,87 @@ function reduce_duplicates!(rows::Vector{T}, cols::Vector{T}, vals::Vector{S}) w
     findnz(sparse(rows, cols, vals))
 end
 
-function MOI.delete!(m::LinQuadOptimizer, c::QCI{<: LinSets})
-    __assert_valid__(m, c)
-    delete_constraint_name(m, c)
-    dict = constrdict(m, c)
-    row = dict[c]
-    delete_quadratic_constraints!(m, row, row)
-    deleteat!(m.qconstraint_primal_solution, row)
-    deleteat!(m.qconstraint_dual_solution, row)
+"""
+    canonical_reduction(model::LinQuadOptimizer, func::Quad)
+
+Reduce a ScalarQuadraticFunction into five arrays, returned in the following
+order:
+ 1. a vector of affine column indices
+ 2. a vector of affine coefficients
+ 3. a vector of quadratic row indices
+ 4. a vector of quadratic column indices
+ 5. a vector of quadratic coefficients
+"""
+function canonical_reduction(model::LinQuadOptimizer, func::Quad)
+    quad_columns_1, quad_columns_2, quad_coefficients = reduce_duplicates!(
+        [get_column(model, term.variable_index_1) for term in func.quadratic_terms],
+        [get_column(model, term.variable_index_2) for term in func.quadratic_terms],
+        [term.coefficient for term in func.quadratic_terms]
+    )
+    affine_columns = [get_column(model, term.variable_index) for term in func.affine_terms]
+    affine_coefficients = [term.coefficient for term in func.affine_terms]
+    return affine_columns, affine_coefficients, quad_columns_1, quad_columns_2, quad_coefficients
+end
+
+function MOI.addconstraint!(model::LinQuadOptimizer, func::Quad, set::S) where S <: Union{LE, GE, EQ}
+    add_quadratic_constraint(model, func, set)
+    model.last_constraint_reference += 1
+    index = QCI{S}(model.last_constraint_reference)
+    dict = constrdict(model, index)
+    push!(model.qconstraint_primal_solution, NaN)
+    push!(model.qconstraint_dual_solution, NaN)
+    dict[index] = get_number_quadratic_constraints(model)
+    return index
+end
+
+function add_quadratic_constraint(model::LinQuadOptimizer, func::Quad, set::S) where S<: Union{LE, GE, EQ}
+    add_quadratic_constraint(model, func, backend_type(model, set),
+                             MOIU.getconstant(set))
+end
+
+function add_quadratic_constraint(model::LinQuadOptimizer, func::Quad, sense, rhs::Float64)
+    if abs(func.constant) > 0
+        Compat.@warn("Constant in quadratic function. Moving into set")
+    end
+    (aff_cols, aff_coeffs, I, J, V) = canonical_reduction(model, func)
+    add_quadratic_constraint!(model, aff_cols, aff_coeffs, rhs - func.constant,
+                              sense, I, J, V)
+end
+
+function MOI.delete!(model::LinQuadOptimizer, index::QCI{<: LinSets})
+    __assert_valid__(model, index)
+    delete_constraint_name(model, index)
+    dict = constrdict(model, index)
+    row = dict[index]
+    delete_quadratic_constraints!(model, row, row)
+    deleteat!(model.qconstraint_primal_solution, row)
+    deleteat!(model.qconstraint_dual_solution, row)
     # shift all the other references
-    shift_references_after_delete_quadratic!(m, row)
-    delete!(dict, c)
+    shift_references_after_delete_quadratic!(model, row)
+    delete!(dict, index)
 end
 
 #=
     Constraint set of Linear function
 =#
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{QCI{S}}) where S <: Union{LE, GE, EQ} = true
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::QCI{S}) where S <: Union{LE, GE, EQ}
-    rhs = get_quadratic_rhs(m, m[c])
+MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{QCI{S}}) where S <: Union{LE, GE, EQ} = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintSet, index::QCI{S}) where S <: Union{LE, GE, EQ}
+    rhs = get_quadratic_rhs(model, model[index])
     S(rhs)
 end
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{QCI{IV}}) = false
+MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{QCI{IV}}) = false
 
 #=
     Constraint function of Linear function
 =#
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{<:QCI{<: LinSets}}) = true
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::QCI{<: LinSets})
-    # TODO more efficiently
-    colidx, coefs, Q = get_quadratic_constraint(m, m[c])
+MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{<:QCI{<: LinSets}}) = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintFunction, index::QCI{<: LinSets})
+    aff_cols, aff_coeffs, Q = get_quadratic_constraint(model, model[index])
     affine_terms = map(
-        (v,c)->MOI.ScalarAffineTerm{Float64}(c, m.variable_references[v]),
-        colidx,
-        coefs
-    )
+        (col, coef)->MOI.ScalarAffineTerm{Float64}(coef, model.variable_references[col]),
+        aff_cols, aff_coeffs)
     rows = rowvals(Q)
     vals = nonzeros(Q)
     nrows, ncols = size(Q)
@@ -129,7 +134,8 @@ function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::QCI{<: LinSet
         for j in nzrange(Q, i)
             row = rows[j]
             val = vals[j]
-            push!(quadratic_terms, MOI.ScalarQuadraticTerm{Float64}(2*val, m.variable_references[row], m.variable_references[i]))
+            push!(quadratic_terms, MOI.ScalarQuadraticTerm{Float64}(2*val,
+                model.variable_references[row], model.variable_references[i]))
         end
     end
     Quad(affine_terms, quadratic_terms, 0.0) # constant was moved into set

--- a/src/constraints/singlevariable.jl
+++ b/src/constraints/singlevariable.jl
@@ -67,7 +67,7 @@ end
 
 # add constraint
 function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::S) where S <: LinSets
-    _assert_add_constraint(m, SinVar, S)
+    __assert_supported_constraint__(m, SinVar, S)
     checkexisting(m, v, set)
     checkconflicting(m, v, set, MOI.Semicontinuous(0.0, 0.0))
     checkconflicting(m, v, set, MOI.Semiinteger(0.0, 0.0))
@@ -83,8 +83,8 @@ end
 
 # delete constraint
 function MOI.delete!(m::LinQuadOptimizer, c::SVCI{S}) where S <: LinSets
-    _assert_valid(m, c)
-    deleteconstraintname!(m, c)
+    __assert_valid__(m, c)
+    delete_constraint_name(m, c)
     dict = constrdict(m, c)
     vref = dict[c]
     setvariablebound!(m, SinVar(vref), IV(-Inf, Inf))
@@ -136,7 +136,7 @@ we can revert to the old bounds
 Xpress is worse, once binary, the bounds are changed independently of what the user does
 =#
 function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::MOI.ZeroOne)
-    _assert_add_constraint(m, SinVar, MOI.ZeroOne)
+    __assert_supported_constraint__(m, SinVar, MOI.ZeroOne)
     checkexisting(m, v, set)
     checkconflicting(m, v, set, MOI.Integer())
     checkconflicting(m, v, set, MOI.Semicontinuous(0.0, 0.0))
@@ -156,15 +156,15 @@ function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::MOI.ZeroOne)
 end
 
 function MOI.delete!(m::LinQuadOptimizer, c::SVCI{MOI.ZeroOne})
-    _assert_valid(m, c)
-    deleteconstraintname!(m, c)
+    __assert_valid__(m, c)
+    delete_constraint_name(m, c)
     dict = constrdict(m, c)
     (v, lb, ub) = dict[c]
     change_variable_types!(m, [getcol(m, v)], [backend_type(m, Val{:Continuous}())])
     setvariablebound!(m, getcol(m, v), ub, backend_type(m, Val{:Upperbound}()))
     setvariablebound!(m, getcol(m, v), lb, backend_type(m, Val{:Lowerbound}()))
     delete!(dict, c)
-    if !hasinteger(m)
+    if !has_integer(m)
         make_problem_type_continuous(m)
     end
 end
@@ -180,7 +180,7 @@ MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{MOI.ZeroOne}) = S
 =#
 
 function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::MOI.Integer)
-    _assert_add_constraint(m, SinVar, MOI.Integer)
+    __assert_supported_constraint__(m, SinVar, MOI.Integer)
     checkexisting(m, v, set)
     checkconflicting(m, v, set, MOI.ZeroOne())
     checkconflicting(m, v, set, MOI.Semicontinuous(0.0, 0.0))
@@ -196,13 +196,13 @@ function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::MOI.Integer)
 end
 
 function MOI.delete!(m::LinQuadOptimizer, c::SVCI{MOI.Integer})
-    _assert_valid(m, c)
-    deleteconstraintname!(m, c)
+    __assert_valid__(m, c)
+    delete_constraint_name(m, c)
     dict = constrdict(m, c)
     v = dict[c]
     change_variable_types!(m, [getcol(m, v)], [backend_type(m, Val{:Continuous}())])
     delete!(dict, c)
-    if !hasinteger(m)
+    if !has_integer(m)
         make_problem_type_continuous(m)
     end
 end
@@ -218,7 +218,7 @@ MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{MOI.Integer}) = S
 =#
 const SEMI_TYPES = Union{MOI.Semicontinuous{Float64}, MOI.Semiinteger{Float64}}
 function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::S) where S <: SEMI_TYPES
-    _assert_add_constraint(m, SinVar, S)
+    __assert_supported_constraint__(m, SinVar, S)
     checkexisting(m, v, set)
     checkconflicting(m, v, set, MOI.ZeroOne())
     checkconflicting(m, v, set, MOI.Integer())
@@ -240,15 +240,15 @@ function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::S) where S <: S
 end
 
 function MOI.delete!(m::LinQuadOptimizer, c::SVCI{<:SEMI_TYPES})
-    _assert_valid(m, c)
-    deleteconstraintname!(m, c)
+    __assert_valid__(m, c)
+    delete_constraint_name(m, c)
     dict = constrdict(m, c)
     v = dict[c]
     change_variable_types!(m, [getcol(m, v)], [backend_type(m, Val{:Continuous}())])
     setvariablebound!(m, getcol(m, v), Inf, backend_type(m, Val{:Upperbound}()))
     setvariablebound!(m, getcol(m, v), -Inf, backend_type(m, Val{:Lowerbound}()))
     delete!(dict, c)
-    if !hasinteger(m)
+    if !has_integer(m)
         make_problem_type_continuous(m)
     end
 end

--- a/src/constraints/singlevariable.jl
+++ b/src/constraints/singlevariable.jl
@@ -67,6 +67,7 @@ end
 
 # add constraint
 function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::S) where S <: LinSets
+    _assert_add_constraint(m, SinVar, S)
     checkexisting(m, v, set)
     checkconflicting(m, v, set, MOI.Semicontinuous(0.0, 0.0))
     checkconflicting(m, v, set, MOI.Semiinteger(0.0, 0.0))
@@ -81,8 +82,8 @@ function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::S) where S <: L
 end
 
 # delete constraint
-MOI.candelete(m::LinQuadOptimizer, c::SVCI{S}) where S <: LinSets = MOI.isvalid(m, c)
 function MOI.delete!(m::LinQuadOptimizer, c::SVCI{S}) where S <: LinSets
+    _assert_valid(m, c)
     deleteconstraintname!(m, c)
     dict = constrdict(m, c)
     vref = dict[c]
@@ -120,7 +121,7 @@ function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{<: LinSe
 end
 
 # modify
-MOI.canset(::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{SVCI{S}}) where S <: LinSets = true
+MOI.supports(::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{SVCI{S}}) where S<:LinSets = true
 function MOI.set!(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{S}, newset::S) where S <: LinSets
     setvariablebound!(m, SinVar(m[c]), newset)
 end
@@ -135,6 +136,7 @@ we can revert to the old bounds
 Xpress is worse, once binary, the bounds are changed independently of what the user does
 =#
 function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::MOI.ZeroOne)
+    _assert_add_constraint(m, SinVar, MOI.ZeroOne)
     checkexisting(m, v, set)
     checkconflicting(m, v, set, MOI.Integer())
     checkconflicting(m, v, set, MOI.Semicontinuous(0.0, 0.0))
@@ -153,8 +155,8 @@ function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::MOI.ZeroOne)
     ref
 end
 
-MOI.candelete(m::LinQuadOptimizer, c::SVCI{MOI.ZeroOne}) = MOI.isvalid(m, c)
 function MOI.delete!(m::LinQuadOptimizer, c::SVCI{MOI.ZeroOne})
+    _assert_valid(m, c)
     deleteconstraintname!(m, c)
     dict = constrdict(m, c)
     (v, lb, ub) = dict[c]
@@ -178,6 +180,7 @@ MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{MOI.ZeroOne}) = S
 =#
 
 function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::MOI.Integer)
+    _assert_add_constraint(m, SinVar, MOI.Integer)
     checkexisting(m, v, set)
     checkconflicting(m, v, set, MOI.ZeroOne())
     checkconflicting(m, v, set, MOI.Semicontinuous(0.0, 0.0))
@@ -192,8 +195,8 @@ function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::MOI.Integer)
     ref
 end
 
-MOI.candelete(m::LinQuadOptimizer, c::SVCI{MOI.Integer}) = MOI.isvalid(m, c)
 function MOI.delete!(m::LinQuadOptimizer, c::SVCI{MOI.Integer})
+    _assert_valid(m, c)
     deleteconstraintname!(m, c)
     dict = constrdict(m, c)
     v = dict[c]
@@ -215,6 +218,7 @@ MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{MOI.Integer}) = S
 =#
 const SEMI_TYPES = Union{MOI.Semicontinuous{Float64}, MOI.Semiinteger{Float64}}
 function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::S) where S <: SEMI_TYPES
+    _assert_add_constraint(m, SinVar, S)
     checkexisting(m, v, set)
     checkconflicting(m, v, set, MOI.ZeroOne())
     checkconflicting(m, v, set, MOI.Integer())
@@ -235,8 +239,8 @@ function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::S) where S <: S
     ref
 end
 
-MOI.candelete(m::LinQuadOptimizer, c::SVCI{<:SEMI_TYPES}) = MOI.isvalid(m, c)
 function MOI.delete!(m::LinQuadOptimizer, c::SVCI{<:SEMI_TYPES})
+    _assert_valid(m, c)
     deleteconstraintname!(m, c)
     dict = constrdict(m, c)
     v = dict[c]

--- a/src/constraints/singlevariable.jl
+++ b/src/constraints/singlevariable.jl
@@ -10,120 +10,146 @@
         SingleVariable -in- Semiinteger
         SingleVariable -in- Semicontinuous
 =#
-constrdict(m::LinQuadOptimizer, ::SVCI{LE}) = cmap(m).upper_bound
-constrdict(m::LinQuadOptimizer, ::SVCI{GE}) = cmap(m).lower_bound
-constrdict(m::LinQuadOptimizer, ::SVCI{EQ}) = cmap(m).fixed_bound
-constrdict(m::LinQuadOptimizer, ::SVCI{IV}) = cmap(m).interval_bound
+constrdict(model::LinQuadOptimizer, ::SVCI{LE}) = cmap(model).upper_bound
+constrdict(model::LinQuadOptimizer, ::SVCI{GE}) = cmap(model).lower_bound
+constrdict(model::LinQuadOptimizer, ::SVCI{EQ}) = cmap(model).fixed_bound
+constrdict(model::LinQuadOptimizer, ::SVCI{IV}) = cmap(model).interval_bound
 
-constrdict(m::LinQuadOptimizer, ::SVCI{MOI.ZeroOne}) = cmap(m).binary
-constrdict(m::LinQuadOptimizer, ::SVCI{MOI.Integer}) = cmap(m).integer
+constrdict(model::LinQuadOptimizer, ::SVCI{MOI.ZeroOne}) = cmap(model).binary
+constrdict(model::LinQuadOptimizer, ::SVCI{MOI.Integer}) = cmap(model).integer
 
-constrdict(m::LinQuadOptimizer, ::SVCI{MOI.Semicontinuous{Float64}}) = cmap(m).semicontinuous
-constrdict(m::LinQuadOptimizer, ::SVCI{MOI.Semiinteger{Float64}}) = cmap(m).semiinteger
+constrdict(model::LinQuadOptimizer, ::SVCI{MOI.Semicontinuous{Float64}}) = cmap(model).semicontinuous
+constrdict(model::LinQuadOptimizer, ::SVCI{MOI.Semiinteger{Float64}}) = cmap(model).semiinteger
 
-function setvariablebound!(m::LinQuadOptimizer, col::Int, bound::Float64, sense::Cchar)
-    change_variable_bounds!(m, [col], [bound], [sense])
+function set_variable_bound(model::LinQuadOptimizer, column::Int,
+                            bound::Float64, sense)
+    change_variable_bounds!(model, [column], [bound], [sense])
 end
 
-function setvariablebound!(m::LinQuadOptimizer, v::SinVar, set::LE)
-    setvariablebound!(m, get_column(m, v), set.upper, backend_type(m, Val{:Upperbound}()))
+function set_variable_bound(model::LinQuadOptimizer, v::SinVar, set::LE)
+    set_variable_bound(model, get_column(model, v), set.upper,
+                      backend_type(model, Val{:Upperbound}()))
 end
-function setvariablebound!(m::LinQuadOptimizer, v::SinVar, set::GE)
-    setvariablebound!(m, get_column(m, v), set.lower, backend_type(m, Val{:Lowerbound}()))
+function set_variable_bound(model::LinQuadOptimizer, v::SinVar, set::GE)
+    set_variable_bound(model, get_column(model, v), set.lower,
+                      backend_type(model, Val{:Lowerbound}()))
 end
-function setvariablebound!(m::LinQuadOptimizer, v::SinVar, set::EQ)
-    setvariablebound!(m, get_column(m, v), set.value, backend_type(m, Val{:Upperbound}()))
-    setvariablebound!(m, get_column(m, v), set.value, backend_type(m, Val{:Lowerbound}()))
+function set_variable_bound(model::LinQuadOptimizer, v::SinVar, set::EQ)
+    set_variable_bound(model, get_column(model, v), set.value,
+                      backend_type(model, Val{:Upperbound}()))
+    set_variable_bound(model, get_column(model, v), set.value,
+                      backend_type(model, Val{:Lowerbound}()))
 end
-function setvariablebound!(m::LinQuadOptimizer, v::SinVar, set::IV)
-    setvariablebound!(m, get_column(m, v), set.upper, backend_type(m, Val{:Upperbound}()))
-    setvariablebound!(m, get_column(m, v), set.lower, backend_type(m, Val{:Lowerbound}()))
+function set_variable_bound(model::LinQuadOptimizer, v::SinVar, set::IV)
+    set_variable_bound(model, get_column(model, v), set.upper,
+                      backend_type(model, Val{:Upperbound}()))
+    set_variable_bound(model, get_column(model, v), set.lower,
+                      backend_type(model, Val{:Lowerbound}()))
 end
 
-SVCI(v::SinVar, ::S) where S = SVCI{S}(v.variable.value)
+"""
+    has_value(dict::Dict{K, V}, value::V) where {K, V}
 
-function hasvalue(d::Dict, val)
-    for v in values(d)
-        if v == val
-            return true
+Return true if `dict` has a `key=>value` pair with `value`.
+"""
+function has_value(dict::Dict{K, V}, value::V) where {K, V}
+    return value in values(dict)
+end
+
+"""
+    __check_for_conflicting__(model::LinQuadOptimizer, variable::SinVar, set,
+                              conflicting_type::Type{<:AbstractSet})
+
+Throw an error if `variable` is already constrained to be in a set of type
+`conflicting_type`.
+"""
+function __check_for_conflicting__(model::LinQuadOptimizer, variable::SinVar, set,
+                                   conflict_type::Type{<:MOI.AbstractSet})
+    if has_value(constrdict(model, SVCI{conflict_type}(0)), variable.variable)
+        error("Cannot add constraint $(variable)-in-$(set) as it is already " *
+              "constrained by a set of type $(conflict_type).")
+    end
+end
+
+function __check_for_conflicting__(model::LinQuadOptimizer, variable::SinVar, set,
+                                   conflict_type::Type{MOI.ZeroOne})
+    for (index, lower, upper) in values(constrdict(model, SVCI{conflict_type}(0)))
+        if index == variable.variable
+            error("Cannot add constraint $(variable)-in-$(set) as it is already " *
+                  "constrained by a set of type $(conflict_type).")
         end
     end
-    return false
 end
 
-function checkexisting(m::LinQuadOptimizer, v::SinVar, set::S) where S
-    ref = SVCI(v, set)
-    if hasvalue(constrdict(m, ref), v.variable)
-        error("Adding the same constraint type: $(S) is not allowed for SingleVariable function")
+
+"""
+    __check_for_conflicting__(model::LinQuadOptimizer, variable::SinVar, set,
+                              conflicting_types::AbstractSet...)
+
+Throw an error if `variable` is constrained to be in a set whose type is one of
+`conflicting_types`.
+"""
+function __check_for_conflicting__(model::LinQuadOptimizer, variable::SinVar, set,
+                                   conflicting_types...)
+    for conflict_type in conflicting_types
+        __check_for_conflicting__(model, variable, set, conflict_type)
     end
 end
 
-function checkconflicting(m::LinQuadOptimizer, v::SinVar, set_to_add::S0, set_to_test::S) where S where S0
-    ref = SVCI(v, set_to_test)
-    if hasvalue(constrdict(m, ref), v.variable)
-        error("Adding the same constraint type: $(S0) is not allowed for SingleVariable function because there is constraint of type $(S) tied to the respective variable")
-    end
+function MOI.addconstraint!(model::LinQuadOptimizer, variable::SinVar, set::S) where S <: LinSets
+    __assert_supported_constraint__(model, SinVar, S)
+    __check_for_conflicting__(model, variable, set,
+        S, MOI.Semicontinuous{Float64}, MOI.Semiinteger{Float64}, MOI.ZeroOne)
+    set_variable_bound(model, variable, set)
+    model.last_constraint_reference += 1
+    index = SVCI{S}(model.last_constraint_reference)
+    dict = constrdict(model, index)
+    dict[index] = variable.variable
+    return index
 end
 
-# add constraint
-function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::S) where S <: LinSets
-    __assert_supported_constraint__(m, SinVar, S)
-    checkexisting(m, v, set)
-    checkconflicting(m, v, set, MOI.Semicontinuous(0.0, 0.0))
-    checkconflicting(m, v, set, MOI.Semiinteger(0.0, 0.0))
-    checkconflicting(m, v, set, MOI.ZeroOne())
-    setvariablebound!(m, v, set)
-    m.last_constraint_reference += 1
-    ref = SVCI{S}(m.last_constraint_reference)
-    # ref = SVCI(v, set)
-    dict = constrdict(m, ref)
-    dict[ref] = v.variable
-    ref
-end
-
-# delete constraint
-function MOI.delete!(m::LinQuadOptimizer, c::SVCI{S}) where S <: LinSets
-    __assert_valid__(m, c)
-    delete_constraint_name(m, c)
-    dict = constrdict(m, c)
-    vref = dict[c]
-    setvariablebound!(m, SinVar(vref), IV(-Inf, Inf))
-    delete!(dict, c)
+function MOI.delete!(model::LinQuadOptimizer, index::SVCI{S}) where S <: LinSets
+    __assert_valid__(model, index)
+    delete_constraint_name(model, index)
+    dict = constrdict(model, index)
+    variable_index = dict[index]
+    set_variable_bound(model, SinVar(variable_index), IV(-Inf, Inf))
+    delete!(dict, index)
 end
 
 # constraint set
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{SVCI{S}}) where S <: LinSets = true
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{LE})
+MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{SVCI{S}}) where S <: LinSets = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintSet, index::SVCI{LE})
     MOI.LessThan{Float64}(
-        get_variable_upperbound(m, get_column(m, m[c]))
+        get_variable_upperbound(model, get_column(model, model[index]))
     )
 end
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{GE})
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintSet, index::SVCI{GE})
     MOI.GreaterThan{Float64}(
-        get_variable_lowerbound(m, get_column(m, m[c]))
+        get_variable_lowerbound(model, get_column(model, model[index]))
     )
 end
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{EQ})
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintSet, index::SVCI{EQ})
     MOI.EqualTo{Float64}(
-        get_variable_lowerbound(m, get_column(m, m[c]))
+        get_variable_lowerbound(model, get_column(model, model[index]))
     )
 end
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{IV})
-    lb = get_variable_lowerbound(m, get_column(m, m[c]))
-    ub = get_variable_upperbound(m, get_column(m, m[c]))
-    return MOI.Interval{Float64}(lb, ub)
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintSet, index::SVCI{IV})
+    column = get_column(model, model[index])
+    return MOI.Interval{Float64}(get_variable_lowerbound(model, column),
+                                 get_variable_upperbound(model, column))
 end
 
 # constraint function
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{SVCI{S}}) where S <: LinSets = true
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{<: LinSets})
-    return SinVar(m[c])
+MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{SVCI{S}}) where S <: LinSets = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintFunction, index::SVCI{<: LinSets})
+    return SinVar(model[index])
 end
 
 # modify
 MOI.supports(::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{SVCI{S}}) where S<:LinSets = true
-function MOI.set!(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{S}, newset::S) where S <: LinSets
-    setvariablebound!(m, SinVar(m[c]), newset)
+function MOI.set!(model::LinQuadOptimizer, ::MOI.ConstraintSet, index::SVCI{S}, newset::S) where S <: LinSets
+    set_variable_bound(model, SinVar(model[index]), newset)
 end
 
 #=
@@ -135,132 +161,146 @@ we can revert to the old bounds
 
 Xpress is worse, once binary, the bounds are changed independently of what the user does
 =#
-function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::MOI.ZeroOne)
-    __assert_supported_constraint__(m, SinVar, MOI.ZeroOne)
-    checkexisting(m, v, set)
-    checkconflicting(m, v, set, MOI.Integer())
-    checkconflicting(m, v, set, MOI.Semicontinuous(0.0, 0.0))
-    checkconflicting(m, v, set, MOI.Semiinteger(0.0, 0.0))
-    m.last_constraint_reference += 1
-    ref = SVCI{MOI.ZeroOne}(m.last_constraint_reference)
-    # ref = SVCI(v, set)
-    dict = constrdict(m, ref)
-    ub = get_variable_upperbound(m, get_column(m, v))
-    lb = get_variable_lowerbound(m, get_column(m, v))
-    dict[ref] = (v.variable, lb, ub)
-    change_variable_types!(m, [get_column(m, v)], [backend_type(m, set)])
-    setvariablebound!(m, get_column(m, v), 1.0, backend_type(m, Val{:Upperbound}()))
-    setvariablebound!(m, get_column(m, v), 0.0, backend_type(m, Val{:Lowerbound}()))
-    make_problem_type_integer(m)
-    ref
+function MOI.addconstraint!(model::LinQuadOptimizer, variable::SinVar, set::MOI.ZeroOne)
+    __assert_supported_constraint__(model, SinVar, MOI.ZeroOne)
+    __check_for_conflicting__(model, variable, set, MOI.ZeroOne, MOI.Integer,
+        MOI.Semicontinuous{Float64}, MOI.Semiinteger{Float64})
+    model.last_constraint_reference += 1
+    index = SVCI{MOI.ZeroOne}(model.last_constraint_reference)
+    column = get_column(model, variable)
+    dict = constrdict(model, index)
+    dict[index] = (variable.variable, get_variable_lowerbound(model, column),
+                    get_variable_upperbound(model, column))
+    change_variable_types!(model, [column], [backend_type(model, set)])
+    set_variable_bound(model, column, 1.0,
+                       backend_type(model, Val{:Upperbound}()))
+    set_variable_bound(model, column, 0.0,
+                       backend_type(model, Val{:Lowerbound}()))
+    make_problem_type_integer(model)
+    return index
 end
 
-function MOI.delete!(m::LinQuadOptimizer, c::SVCI{MOI.ZeroOne})
-    __assert_valid__(m, c)
-    delete_constraint_name(m, c)
-    dict = constrdict(m, c)
-    (v, lb, ub) = dict[c]
-    change_variable_types!(m, [get_column(m, v)], [backend_type(m, Val{:Continuous}())])
-    setvariablebound!(m, get_column(m, v), ub, backend_type(m, Val{:Upperbound}()))
-    setvariablebound!(m, get_column(m, v), lb, backend_type(m, Val{:Lowerbound}()))
-    delete!(dict, c)
-    if !has_integer(m)
-        make_problem_type_continuous(m)
+function MOI.delete!(model::LinQuadOptimizer, index::SVCI{MOI.ZeroOne})
+    __assert_valid__(model, index)
+    delete_constraint_name(model, index)
+    dict = constrdict(model, index)
+    (variable, lower, upper) = dict[index]
+    column = get_column(model, variable)
+    change_variable_types!(model, [column],
+                           [backend_type(model, Val{:Continuous}())])
+    set_variable_bound(model, column, upper,
+                       backend_type(model, Val{:Upperbound}()))
+    set_variable_bound(model, column, lower,
+                       backend_type(model, Val{:Lowerbound}()))
+    delete!(dict, index)
+    if !has_integer(model)
+        make_problem_type_continuous(model)
     end
 end
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{SVCI{MOI.ZeroOne}}) = true
-MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{MOI.ZeroOne}) = MOI.ZeroOne()
+MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{SVCI{MOI.ZeroOne}}) = true
+function MOI.get(::LinQuadOptimizer, ::MOI.ConstraintSet, ::SVCI{MOI.ZeroOne})
+    return MOI.ZeroOne()
+end
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{SVCI{MOI.ZeroOne}}) = true
-MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{MOI.ZeroOne}) = SinVar(m[c][1])
+MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{SVCI{MOI.ZeroOne}}) = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintFunction, index::SVCI{MOI.ZeroOne})
+    return SinVar(model[index][1])
+end
 
 #=
     Integer constraints
 =#
 
-function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::MOI.Integer)
-    __assert_supported_constraint__(m, SinVar, MOI.Integer)
-    checkexisting(m, v, set)
-    checkconflicting(m, v, set, MOI.ZeroOne())
-    checkconflicting(m, v, set, MOI.Semicontinuous(0.0, 0.0))
-    checkconflicting(m, v, set, MOI.Semiinteger(0.0, 0.0))
-    change_variable_types!(m, [get_column(m, v)], [backend_type(m, set)])
-    m.last_constraint_reference += 1
-    ref = SVCI{MOI.Integer}(m.last_constraint_reference)
-    # ref = SVCI(v, set)
-    dict = constrdict(m, ref)
-    dict[ref] = v.variable
-    make_problem_type_integer(m)
-    ref
+function MOI.addconstraint!(model::LinQuadOptimizer, variable::SinVar, set::MOI.Integer)
+    __assert_supported_constraint__(model, SinVar, MOI.Integer)
+    __check_for_conflicting__(model, variable, set, MOI.ZeroOne,
+        MOI.Semicontinuous{Float64}, MOI.Semiinteger{Float64})
+    change_variable_types!(model, [get_column(model, variable)],
+                           [backend_type(model, set)])
+    model.last_constraint_reference += 1
+    index = SVCI{MOI.Integer}(model.last_constraint_reference)
+    dict = constrdict(model, index)
+    dict[index] = variable.variable
+    make_problem_type_integer(model)
+    return index
 end
 
-function MOI.delete!(m::LinQuadOptimizer, c::SVCI{MOI.Integer})
-    __assert_valid__(m, c)
-    delete_constraint_name(m, c)
-    dict = constrdict(m, c)
-    v = dict[c]
-    change_variable_types!(m, [get_column(m, v)], [backend_type(m, Val{:Continuous}())])
-    delete!(dict, c)
-    if !has_integer(m)
-        make_problem_type_continuous(m)
+function MOI.delete!(model::LinQuadOptimizer, index::SVCI{MOI.Integer})
+    __assert_valid__(model, index)
+    delete_constraint_name(model, index)
+    dict = constrdict(model, index)
+    variable = dict[index]
+    change_variable_types!(model, [get_column(model, variable)],
+                           [backend_type(model, Val{:Continuous}())])
+    delete!(dict, index)
+    if !has_integer(model)
+        make_problem_type_continuous(model)
     end
 end
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{SVCI{MOI.Integer}}) = true
-MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{MOI.Integer}) = MOI.Integer()
+MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{SVCI{MOI.Integer}}) = true
+function MOI.get(::LinQuadOptimizer, ::MOI.ConstraintSet, ::SVCI{MOI.Integer})
+    return MOI.Integer()
+end
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{SVCI{MOI.Integer}}) = true
-MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{MOI.Integer}) = SinVar(m[c])
+MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{SVCI{MOI.Integer}}) = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintFunction,
+                 index::SVCI{MOI.Integer})
+    return SinVar(model[index])
+end
 
 #=
     Semicontinuous / Semiinteger constraints
 =#
 const SEMI_TYPES = Union{MOI.Semicontinuous{Float64}, MOI.Semiinteger{Float64}}
-function MOI.addconstraint!(m::LinQuadOptimizer, v::SinVar, set::S) where S <: SEMI_TYPES
-    __assert_supported_constraint__(m, SinVar, S)
-    checkexisting(m, v, set)
-    checkconflicting(m, v, set, MOI.ZeroOne())
-    checkconflicting(m, v, set, MOI.Integer())
+function MOI.addconstraint!(model::LinQuadOptimizer, variable::SinVar, set::S) where S <: SEMI_TYPES
+    __assert_supported_constraint__(model, SinVar, S)
+    __check_for_conflicting__(model, variable, set, S, MOI.ZeroOne, MOI.Integer)
     if S == MOI.Semicontinuous{Float64}
-        checkconflicting(m, v, set, MOI.Semiinteger(0.0, 0.0))
+        __check_for_conflicting__(model, variable, set, MOI.Semiinteger{Float64})
     else
-        checkconflicting(m, v, set, MOI.Semicontinuous(0.0, 0.0))
+        __check_for_conflicting__(model, variable, set, MOI.Semicontinuous{Float64})
     end
-    change_variable_types!(m, [get_column(m, v)], [backend_type(m, set)])
-    setvariablebound!(m, get_column(m, v), set.upper, backend_type(m, Val{:Upperbound}()))
-    setvariablebound!(m, get_column(m, v), set.lower, backend_type(m, Val{:Lowerbound}()))
-    m.last_constraint_reference += 1
-    ref = SVCI{S}(m.last_constraint_reference)
-    # ref = SVCI(v, set)
-    dict = constrdict(m, ref)
-    dict[ref] = v.variable
-    make_problem_type_integer(m)
-    ref
+    column = get_column(model, variable)
+    change_variable_types!(model, [column], [backend_type(model, set)])
+    set_variable_bound(model, column, set.upper,
+                       backend_type(model, Val{:Upperbound}()))
+    set_variable_bound(model, column, set.lower,
+                       backend_type(model, Val{:Lowerbound}()))
+    model.last_constraint_reference += 1
+    index = SVCI{S}(model.last_constraint_reference)
+    dict = constrdict(model, index)
+    dict[index] = variable.variable
+    make_problem_type_integer(model)
+    return index
 end
 
-function MOI.delete!(m::LinQuadOptimizer, c::SVCI{<:SEMI_TYPES})
-    __assert_valid__(m, c)
-    delete_constraint_name(m, c)
-    dict = constrdict(m, c)
-    v = dict[c]
-    change_variable_types!(m, [get_column(m, v)], [backend_type(m, Val{:Continuous}())])
-    setvariablebound!(m, get_column(m, v), Inf, backend_type(m, Val{:Upperbound}()))
-    setvariablebound!(m, get_column(m, v), -Inf, backend_type(m, Val{:Lowerbound}()))
-    delete!(dict, c)
-    if !has_integer(m)
-        make_problem_type_continuous(m)
+function MOI.delete!(model::LinQuadOptimizer, index::SVCI{<:SEMI_TYPES})
+    __assert_valid__(model, index)
+    delete_constraint_name(model, index)
+    dict = constrdict(model, index)
+    column = get_column(model, dict[index])
+    change_variable_types!(model, [column], [backend_type(model, Val{:Continuous}())])
+    set_variable_bound(model, column, Inf,
+                       backend_type(model, Val{:Upperbound}()))
+    set_variable_bound(model, column, -Inf,
+                       backend_type(model, Val{:Lowerbound}()))
+    delete!(dict, index)
+    if !has_integer(model)
+        make_problem_type_continuous(model)
     end
 end
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{SVCI{S}}) where S <:SEMI_TYPES = true
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::SVCI{S}) where S <: SEMI_TYPES
-    dict = constrdict(m, c)
-    v = dict[c]
-    lb = get_variable_lowerbound(m, get_column(m, v))
-    ub = get_variable_upperbound(m, get_column(m, v))
-    return S(lb, ub)
+MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{SVCI{S}}) where S <:SEMI_TYPES = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintSet, index::SVCI{S}) where S <: SEMI_TYPES
+    dict = constrdict(model, index)
+    column = get_column(model, dict[index])
+    return S(get_variable_lowerbound(model, column),
+             get_variable_upperbound(model, column))
 end
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{SVCI{S}}) where S <:SEMI_TYPES = true
-MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::SVCI{<:SEMI_TYPES}) = SinVar(m[c])
+MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{SVCI{S}}) where S <:SEMI_TYPES = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintFunction, index::SVCI{<:SEMI_TYPES})
+    return SinVar(model[index])
+end

--- a/src/constraints/vectoraffine.jl
+++ b/src/constraints/vectoraffine.jl
@@ -6,7 +6,7 @@ constrdict(m::LinQuadOptimizer, ::VLCI{MOI.Nonpositives}) = cmap(m).nonpositives
 constrdict(m::LinQuadOptimizer, ::VLCI{MOI.Zeros})        = cmap(m).zeros
 
 function MOI.addconstraint!(m::LinQuadOptimizer, func::VecLin, set::S) where S <: VecLinSets
-    _assert_add_constraint(m, VecLin, S)
+    __assert_supported_constraint__(m, VecLin, S)
     @assert MOI.dimension(set) == length(func.constants)
 
     nrows = get_number_linear_constraints(m)
@@ -67,8 +67,8 @@ function MOI.modify!(m::LinQuadOptimizer, ref::VLCI{<: VecLinSets}, chg::MOI.Mul
 end
 
 function MOI.delete!(m::LinQuadOptimizer, c::VLCI{<:VecLinSets})
-    _assert_valid(m, c)
-    deleteconstraintname!(m, c)
+    __assert_valid__(m, c)
+    delete_constraint_name(m, c)
     dict = constrdict(m, c)
     # we delete rows from largest to smallest here so that we don't have
     # to worry about updating references in a greater numbered row, only to

--- a/src/constraints/vectoraffine.jl
+++ b/src/constraints/vectoraffine.jl
@@ -28,7 +28,7 @@ end
 
 function addlinearconstraint!(m::LinQuadOptimizer, func::VecLin, sense::Cchar)
     outputindex   = [term.output_index for term in func.terms]
-    columns       = [getcol(m, term.scalar_term.variable_index) for term in func.terms]
+    columns       = [get_column(m, term.scalar_term.variable_index) for term in func.terms]
     coefficients  = [term.scalar_term.coefficient for term in func.terms]
     # sort into row order
     pidx = sortperm(outputindex)

--- a/src/constraints/vectoraffine.jl
+++ b/src/constraints/vectoraffine.jl
@@ -1,34 +1,31 @@
 #=
     Vector valued constraints
 =#
-constrdict(m::LinQuadOptimizer, ::VLCI{MOI.Nonnegatives}) = cmap(m).nonnegatives
-constrdict(m::LinQuadOptimizer, ::VLCI{MOI.Nonpositives}) = cmap(m).nonpositives
-constrdict(m::LinQuadOptimizer, ::VLCI{MOI.Zeros})        = cmap(m).zeros
+constrdict(model::LinQuadOptimizer, ::VLCI{MOI.Nonnegatives}) = cmap(model).nonnegatives
+constrdict(model::LinQuadOptimizer, ::VLCI{MOI.Nonpositives}) = cmap(model).nonpositives
+constrdict(model::LinQuadOptimizer, ::VLCI{MOI.Zeros})        = cmap(model).zeros
 
-function MOI.addconstraint!(m::LinQuadOptimizer, func::VecLin, set::S) where S <: VecLinSets
-    __assert_supported_constraint__(m, VecLin, S)
+function MOI.addconstraint!(model::LinQuadOptimizer, func::VecLin, set::S) where S <: VecLinSets
+    __assert_supported_constraint__(model, VecLin, S)
     @assert MOI.dimension(set) == length(func.constants)
-
-    nrows = get_number_linear_constraints(m)
-    addlinearconstraint!(m, func, backend_type(m,set))
-    nrows2 = get_number_linear_constraints(m)
-
-    m.last_constraint_reference += 1
-    ref = VLCI{S}(m.last_constraint_reference)
-
-    dict = constrdict(m, ref)
-    dict[ref] = collect(nrows+1:nrows2)
+    nrows = get_number_linear_constraints(model)
+    add_linear_constraint(model, func, backend_type(model, set))
+    nrows2 = get_number_linear_constraints(model)
+    model.last_constraint_reference += 1
+    index = VLCI{S}(model.last_constraint_reference)
+    dict = constrdict(model, index)
+    dict[index] = collect(nrows+1:nrows2)
     for i in 1:MOI.dimension(set)
-        push!(m.constraint_primal_solution, NaN)
-        push!(m.constraint_dual_solution, NaN)
-        push!(m.constraint_constant, func.constants[i])
+        push!(model.constraint_primal_solution, NaN)
+        push!(model.constraint_dual_solution, NaN)
+        push!(model.constraint_constant, func.constants[i])
     end
-    ref
+    return index
 end
 
-function addlinearconstraint!(m::LinQuadOptimizer, func::VecLin, sense::Cchar)
+function add_linear_constraint(model::LinQuadOptimizer, func::VecLin, sense::Cchar)
     outputindex   = [term.output_index for term in func.terms]
-    columns       = [get_column(m, term.scalar_term.variable_index) for term in func.terms]
+    columns       = [get_column(model, term.scalar_term.variable_index) for term in func.terms]
     coefficients  = [term.scalar_term.coefficient for term in func.terms]
     # sort into row order
     pidx = sortperm(outputindex)
@@ -48,40 +45,43 @@ function addlinearconstraint!(m::LinQuadOptimizer, func::VecLin, sense::Cchar)
         end
     end
     A = CSRMatrix{Float64}(row_pointers, columns, coefficients)
-    add_linear_constraints!(m, A, fill(sense, length(func.constants)), -func.constants)
+    add_linear_constraints!(model, A, fill(sense, length(func.constants)), -func.constants)
 end
 
-function MOI.modify!(m::LinQuadOptimizer, ref::VLCI{<: VecLinSets}, chg::MOI.VectorConstantChange{Float64})
-    @assert length(chg.new_constant) == length(m[ref])
-    for (r, v) in zip(m[ref], chg.new_constant)
-        change_rhs_coefficient!(m, r, -v)
-        m.constraint_constant[r] = v
+function MOI.modify!(model::LinQuadOptimizer, index::VLCI{<: VecLinSets},
+                     change::MOI.VectorConstantChange{Float64})
+    rows = model[index]
+    @assert length(change.new_constant) == length(rows)
+    for (row, constant) in zip(rows, change.new_constant)
+        change_rhs_coefficient!(model, row, -constant)
+        model.constraint_constant[row] = constant
     end
 end
 
-function MOI.modify!(m::LinQuadOptimizer, ref::VLCI{<: VecLinSets}, chg::MOI.MultirowChange{Float64})
-    col = m.variable_mapping[chg.variable]
-    for (row, coef) in chg.new_coefficients
-        change_matrix_coefficient!(m, row, col, coef)
+function MOI.modify!(model::LinQuadOptimizer, index::VLCI{<: VecLinSets},
+                     change::MOI.MultirowChange{Float64})
+    column = get_column(model, change.variable)
+    for (row, coef) in change.new_coefficients
+        change_matrix_coefficient!(model, row, column, coef)
     end
 end
 
-function MOI.delete!(m::LinQuadOptimizer, c::VLCI{<:VecLinSets})
-    __assert_valid__(m, c)
-    delete_constraint_name(m, c)
-    dict = constrdict(m, c)
+function MOI.delete!(model::LinQuadOptimizer, index::VLCI{<:VecLinSets})
+    __assert_valid__(model, index)
+    delete_constraint_name(model, index)
+    dict = constrdict(model, index)
     # we delete rows from largest to smallest here so that we don't have
     # to worry about updating references in a greater numbered row, only to
     # modify it later.
-    for row in sort(dict[c], rev=true)
-        delete_linear_constraints!(m, row, row)
-        deleteat!(m.constraint_primal_solution, row)
-        deleteat!(m.constraint_dual_solution, row)
-        deleteat!(m.constraint_constant, row)
+    for row in sort(dict[index], rev=true)
+        delete_linear_constraints!(model, row, row)
+        deleteat!(model.constraint_primal_solution, row)
+        deleteat!(model.constraint_dual_solution, row)
+        deleteat!(model.constraint_constant, row)
         # shift all the other references
-        shift_references_after_delete_affine!(m, row)
+        shift_references_after_delete_affine!(model, row)
     end
-    delete!(dict, c)
+    delete!(dict, index)
 end
 
 
@@ -89,9 +89,9 @@ end
     Constraint set of Linear function
 =#
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{VLCI{S}}) where S <: VecLinSets = true
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::VLCI{S}) where S <: VecLinSets
-    constraint_indices = m[c]
+MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{VLCI{S}}) where S <: VecLinSets = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintSet, index::VLCI{S}) where S <: VecLinSets
+    constraint_indices = model[index]
     S(length(constraint_indices))
 end
 
@@ -99,22 +99,20 @@ end
     Constraint function of Linear function
 =#
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{VLCI{S}}) where S <: VecLinSets = true
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::VLCI{<: VecLinSets})
-    ctrs = m[c]
-    n = length(ctrs)
+MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{VLCI{S}}) where S <: VecLinSets = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintFunction, index::VLCI{<: VecLinSets})
+    rows = model[index]
     constants = Float64[]
     terms = MOI.VectorAffineTerm{Float64}[]
-    for i in 1:n
-        rhs = get_rhs(m, ctrs[i])
+    for (i, row) in enumerate(rows)
+        rhs = get_rhs(model, row)
         push!(constants, -rhs)
-        # TODO more efficiently
-        colidx, coefs = get_linear_constraint(m, ctrs[i])
-        for (column, coefficient) in zip(colidx, coefs)
+        columns, coefficients = get_linear_constraint(model, row)
+        for (column, coefficient) in zip(columns, coefficients)
             push!(terms, MOI.VectorAffineTerm{Float64}(
                     i,
                     MOI.ScalarAffineTerm{Float64}(
-                        coefficient, m.variable_references[column]
+                        coefficient, model.variable_references[column]
                     )
                 )
             )

--- a/src/constraints/vectorofvariables.jl
+++ b/src/constraints/vectorofvariables.jl
@@ -16,6 +16,7 @@ constrdict(m::LinQuadOptimizer, ::VVCI{SOS1}) = cmap(m).sos1
 constrdict(m::LinQuadOptimizer, ::VVCI{SOS2}) = cmap(m).sos2
 
 function MOI.addconstraint!(m::LinQuadOptimizer, func::VecVar, set::S) where S <: VecLinSets
+    _assert_add_constraint(m, VecVar, S)
     @assert length(func.variables) == MOI.dimension(set)
     m.last_constraint_reference += 1
     ref = VVCI{S}(m.last_constraint_reference)
@@ -34,8 +35,8 @@ function MOI.addconstraint!(m::LinQuadOptimizer, func::VecVar, set::S) where S <
     return ref
 end
 
-MOI.candelete(m::LinQuadOptimizer, c::VVCI{S}) where S <: VecLinSets = MOI.isvalid(m, c)
 function MOI.delete!(m::LinQuadOptimizer, c::VVCI{S}) where S <: VecLinSets
+    _assert_valid(m, c)
     deleteconstraintname!(m, c)
     dict = constrdict(m, c)
     # we delete rows from largest to smallest here so that we don't have
@@ -85,6 +86,7 @@ end
 =#
 
 function MOI.addconstraint!(m::LinQuadOptimizer, v::VecVar, sos::S) where S <: Union{MOI.SOS1, MOI.SOS2}
+    _assert_add_constraint(m, VecVar, S)
     make_problem_type_integer(m)
     add_sos_constraint!(m, getcol.(Ref(m), v.variables), sos.weights, backend_type(m, sos))
     m.last_constraint_reference += 1
@@ -94,8 +96,8 @@ function MOI.addconstraint!(m::LinQuadOptimizer, v::VecVar, sos::S) where S <: U
     ref
 end
 
-MOI.candelete(m::LinQuadOptimizer, c::VVCI{<:Union{SOS1, SOS2}}) = MOI.isvalid(m, c)
 function MOI.delete!(m::LinQuadOptimizer, c::VVCI{<:Union{SOS1, SOS2}})
+    _assert_valid(m, c)
     deleteconstraintname!(m, c)
     dict = constrdict(m, c)
     idx = dict[c]

--- a/src/constraints/vectorofvariables.jl
+++ b/src/constraints/vectorofvariables.jl
@@ -8,117 +8,120 @@
         VectorOfVariables -in- SOS1
         VectorOfVariables -in- SOS2
 =#
-constrdict(m::LinQuadOptimizer, ::VVCI{MOI.Nonnegatives}) = cmap(m).vv_nonnegatives
-constrdict(m::LinQuadOptimizer, ::VVCI{MOI.Nonpositives}) = cmap(m).vv_nonpositives
-constrdict(m::LinQuadOptimizer, ::VVCI{MOI.Zeros}) = cmap(m).vv_zeros
+constrdict(model::LinQuadOptimizer, ::VVCI{MOI.Nonnegatives}) = cmap(model).vv_nonnegatives
+constrdict(model::LinQuadOptimizer, ::VVCI{MOI.Nonpositives}) = cmap(model).vv_nonpositives
+constrdict(model::LinQuadOptimizer, ::VVCI{MOI.Zeros}) = cmap(model).vv_zeros
 
-constrdict(m::LinQuadOptimizer, ::VVCI{SOS1}) = cmap(m).sos1
-constrdict(m::LinQuadOptimizer, ::VVCI{SOS2}) = cmap(m).sos2
+constrdict(model::LinQuadOptimizer, ::VVCI{SOS1}) = cmap(model).sos1
+constrdict(model::LinQuadOptimizer, ::VVCI{SOS2}) = cmap(model).sos2
 
-function MOI.addconstraint!(m::LinQuadOptimizer, func::VecVar, set::S) where S <: VecLinSets
-    __assert_supported_constraint__(m, VecVar, S)
+function MOI.addconstraint!(model::LinQuadOptimizer, func::VecVar, set::S) where S <: VecLinSets
+    __assert_supported_constraint__(model, VecVar, S)
     @assert length(func.variables) == MOI.dimension(set)
-    m.last_constraint_reference += 1
-    ref = VVCI{S}(m.last_constraint_reference)
-    rows = get_number_linear_constraints(m)
-    n = MOI.dimension(set)
-    add_linear_constraints!(m,
-        CSRMatrix{Float64}(collect(1:n), get_column.(Ref(m), func.variables), ones(n)),
-        fill(backend_type(m, set),n),
-        zeros(n)
+    rows = get_number_linear_constraints(model)
+    num_vars = MOI.dimension(set)
+    add_linear_constraints!(model,
+        CSRMatrix{Float64}(collect(1:num_vars),
+                           get_column.(Ref(model), func.variables),
+                           ones(num_vars)),
+        fill(backend_type(model, set), num_vars),
+        zeros(num_vars)
     )
-    dict = constrdict(m, ref)
-    dict[ref] = collect(rows+1:rows+n)
-    append!(m.constraint_primal_solution, fill(NaN,n))
-    append!(m.constraint_dual_solution, fill(NaN,n))
-    append!(m.constraint_constant, fill(0.0,n))
-    return ref
+    model.last_constraint_reference += 1
+    index = VVCI{S}(model.last_constraint_reference)
+    dict = constrdict(model, index)
+    dict[index] = collect((rows + 1):(rows + num_vars))
+    append!(model.constraint_primal_solution, fill(NaN, num_vars))
+    append!(model.constraint_dual_solution, fill(NaN, num_vars))
+    append!(model.constraint_constant, fill(0.0, num_vars))
+    return index
 end
 
-function MOI.delete!(m::LinQuadOptimizer, c::VVCI{S}) where S <: VecLinSets
-    __assert_valid__(m, c)
-    delete_constraint_name(m, c)
-    dict = constrdict(m, c)
+function MOI.delete!(model::LinQuadOptimizer, index::VVCI{S}) where S <: VecLinSets
+    __assert_valid__(model, index)
+    delete_constraint_name(model, index)
+    dict = constrdict(model, index)
     # we delete rows from largest to smallest here so that we don't have
     # to worry about updating references in a greater numbered row, only to
     # modify it later.
-    for row in sort(dict[c], rev=true)
-        delete_linear_constraints!(m, row, row)
-        deleteat!(m.constraint_primal_solution, row)
-        deleteat!(m.constraint_dual_solution, row)
-        deleteat!(m.constraint_constant, row)
+    for row in sort(dict[index], rev=true)
+        delete_linear_constraints!(model, row, row)
+        deleteat!(model.constraint_primal_solution, row)
+        deleteat!(model.constraint_dual_solution, row)
+        deleteat!(model.constraint_constant, row)
         # shift all the other references
-        shift_references_after_delete_affine!(m, row)
+        shift_references_after_delete_affine!(model, row)
     end
-    delete!(dict, c)
+    delete!(dict, index)
 end
 
 #=
     Get constraint set of vector variable bound
 =#
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{VVCI{S}}) where S <: VecLinSets = true
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::VVCI{S}) where S <: VecLinSets
-    S(length(m[c]))
+MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{VVCI{S}}) where S <: VecLinSets = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintSet, index::VVCI{S}) where S <: VecLinSets
+    S(length(model[index]))
 end
 
 #=
     Get constraint function of vector variable bound (linear ctr)
 =#
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{VVCI{S}}) where S <: VecLinSets = true
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::VVCI{<: VecLinSets})
-    refs = m[c]
-    out = VarInd[]
-    sizehint!(out, length(refs))
-    for ref in refs
-        colidx, coefs = get_linear_constraint(m, ref)
-        if length(colidx) != 1
+MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{VVCI{S}}) where S <: VecLinSets = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintFunction, index::VVCI{<: VecLinSets})
+    rows = model[index]
+    variables = VarInd[]
+    sizehint!(variables, length(rows))
+    for row in rows
+        cols, coefs = get_linear_constraint(model, row)
+        if length(cols) != 1
             error("Unexpected constraint")
         end
-        push!(out,m.variable_references[colidx[1]])
+        push!(variables, model.variable_references[cols[1]])
     end
-    return VecVar(out)
+    return VecVar(variables)
 end
 
 #=
     SOS constraints
 =#
 
-function MOI.addconstraint!(m::LinQuadOptimizer, v::VecVar, sos::S) where S <: Union{MOI.SOS1, MOI.SOS2}
-    __assert_supported_constraint__(m, VecVar, S)
-    make_problem_type_integer(m)
-    add_sos_constraint!(m, get_column.(Ref(m), v.variables), sos.weights, backend_type(m, sos))
-    m.last_constraint_reference += 1
-    ref = VVCI{S}(m.last_constraint_reference)
-    dict = constrdict(m, ref)
-    dict[ref] = length(cmap(m).sos1) + length(cmap(m).sos2) + 1
-    ref
+function MOI.addconstraint!(model::LinQuadOptimizer, func::VecVar, set::S) where S <: Union{MOI.SOS1, MOI.SOS2}
+    __assert_supported_constraint__(model, VecVar, S)
+    make_problem_type_integer(model)
+    add_sos_constraint!(model, get_column.(Ref(model), func.variables),
+                        set.weights, backend_type(model, set))
+    model.last_constraint_reference += 1
+    index = VVCI{S}(model.last_constraint_reference)
+    dict = constrdict(model, index)
+    dict[index] = length(cmap(model).sos1) + length(cmap(model).sos2) + 1
+    return index
 end
 
-function MOI.delete!(m::LinQuadOptimizer, c::VVCI{<:Union{SOS1, SOS2}})
-    __assert_valid__(m, c)
-    delete_constraint_name(m, c)
-    dict = constrdict(m, c)
-    idx = dict[c]
-    delete_sos!(m, idx, idx)
-    deleteref!(cmap(m).sos1, idx, c)
-    deleteref!(cmap(m).sos2, idx, c)
-    if !has_integer(m)
-        make_problem_type_continuous(m)
+function MOI.delete!(model::LinQuadOptimizer, index::VVCI{<:Union{SOS1, SOS2}})
+    __assert_valid__(model, index)
+    delete_constraint_name(model, index)
+    dict = constrdict(model, index)
+    sos_row = dict[index]
+    delete_sos!(model, sos_row, sos_row)
+    deleteref!(cmap(model).sos1, sos_row, index)
+    deleteref!(cmap(model).sos2, sos_row, index)
+    if !has_integer(model)
+        make_problem_type_continuous(model)
     end
 end
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{VVCI{S}}) where S <: Union{MOI.SOS1, MOI.SOS2} = true
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintSet, c::VVCI{S}) where S <: Union{MOI.SOS1, MOI.SOS2}
-    indices, weights, types = get_sos_constraint(m, m[c])
+MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{VVCI{S}}) where S <: Union{MOI.SOS1, MOI.SOS2} = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintSet, index::VVCI{S}) where S <: Union{MOI.SOS1, MOI.SOS2}
+    indices, weights, types = get_sos_constraint(model, model[index])
     set = S(weights)
-    @assert types == backend_type(m, set)
+    @assert types == backend_type(model, set)
     return set
 end
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{VVCI{S}}) where S <: Union{MOI.SOS1, MOI.SOS2} = true
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintFunction, c::VVCI{<:Union{SOS1, SOS2}})
-    indices, weights, types = get_sos_constraint(m, m[c])
-    return VecVar(m.variable_references[indices])
+MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintFunction, ::Type{VVCI{S}}) where S <: Union{MOI.SOS1, MOI.SOS2} = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintFunction, index::VVCI{<:Union{SOS1, SOS2}})
+    indices, weights, types = get_sos_constraint(model, model[index])
+    return VecVar(model.variable_references[indices])
 end

--- a/src/constraints/vectorofvariables.jl
+++ b/src/constraints/vectorofvariables.jl
@@ -23,7 +23,7 @@ function MOI.addconstraint!(m::LinQuadOptimizer, func::VecVar, set::S) where S <
     rows = get_number_linear_constraints(m)
     n = MOI.dimension(set)
     add_linear_constraints!(m,
-        CSRMatrix{Float64}(collect(1:n), getcol.(Ref(m), func.variables), ones(n)),
+        CSRMatrix{Float64}(collect(1:n), get_column.(Ref(m), func.variables), ones(n)),
         fill(backend_type(m, set),n),
         zeros(n)
     )
@@ -88,7 +88,7 @@ end
 function MOI.addconstraint!(m::LinQuadOptimizer, v::VecVar, sos::S) where S <: Union{MOI.SOS1, MOI.SOS2}
     __assert_supported_constraint__(m, VecVar, S)
     make_problem_type_integer(m)
-    add_sos_constraint!(m, getcol.(Ref(m), v.variables), sos.weights, backend_type(m, sos))
+    add_sos_constraint!(m, get_column.(Ref(m), v.variables), sos.weights, backend_type(m, sos))
     m.last_constraint_reference += 1
     ref = VVCI{S}(m.last_constraint_reference)
     dict = constrdict(m, ref)

--- a/src/copy.jl
+++ b/src/copy.jl
@@ -4,11 +4,13 @@ MOI.copy!(dest::LinQuadOptimizer, src::LinQuadOptimizer; copynames=false) = MOIU
 
 MOI.canget(::LinQuadOptimizer, ::MOI.ListOfVariableAttributesSet) = true
 MOI.get(::LinQuadOptimizer, ::MOI.ListOfVariableAttributesSet) = MOI.AbstractVariableAttribute[]
+
 MOI.canget(::LinQuadOptimizer, ::MOI.ListOfModelAttributesSet) = true
 MOI.get(m::LinQuadOptimizer, ::MOI.ListOfModelAttributesSet) = [
     MOI.ObjectiveSense(),
     MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
     (MOI.get(m, MOI.Name()) != "") ? MOI.Name() : nothing
 ]
+
 MOI.canget(::LinQuadOptimizer, ::MOI.ListOfConstraintAttributesSet{F,S}) where F where S = true
 MOI.get(::LinQuadOptimizer, ::MOI.ListOfConstraintAttributesSet{F,S}) where F where S = MOI.AbstractConstraintAttribute[]

--- a/src/copy.jl
+++ b/src/copy.jl
@@ -1,16 +1,32 @@
-MOI.copy!(dest::LinQuadOptimizer, src::MOI.ModelLike; copynames=false)    = MOIU.defaultcopy!(dest, src, copynames)
-MOI.copy!(dest::MOI.ModelLike,    src::LinQuadOptimizer; copynames=false) = MOIU.defaultcopy!(dest, src, copynames)
-MOI.copy!(dest::LinQuadOptimizer, src::LinQuadOptimizer; copynames=false) = MOIU.defaultcopy!(dest, src, copynames)
+function MOI.copy!(dest::LinQuadOptimizer, src::MOI.ModelLike; copynames=false)
+    return MOIU.defaultcopy!(dest, src, copynames)
+end
+
+function MOI.copy!(dest::MOI.ModelLike,    src::LinQuadOptimizer; copynames=false)
+    return MOIU.defaultcopy!(dest, src, copynames)
+end
+
+function MOI.copy!(dest::LinQuadOptimizer, src::LinQuadOptimizer; copynames=false)
+    return MOIU.defaultcopy!(dest, src, copynames)
+end
 
 MOI.canget(::LinQuadOptimizer, ::MOI.ListOfVariableAttributesSet) = true
-MOI.get(::LinQuadOptimizer, ::MOI.ListOfVariableAttributesSet) = MOI.AbstractVariableAttribute[]
+function MOI.get(::LinQuadOptimizer, ::MOI.ListOfVariableAttributesSet)
+    return MOI.AbstractVariableAttribute[]
+end
 
 MOI.canget(::LinQuadOptimizer, ::MOI.ListOfModelAttributesSet) = true
-MOI.get(m::LinQuadOptimizer, ::MOI.ListOfModelAttributesSet) = [
-    MOI.ObjectiveSense(),
-    MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
-    (MOI.get(m, MOI.Name()) != "") ? MOI.Name() : nothing
-]
+function MOI.get(model::LinQuadOptimizer, ::MOI.ListOfModelAttributesSet)
+    return [MOI.ObjectiveSense(),
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+        # TODO(odow): why is `nothing` returned?
+        (MOI.get(model, MOI.Name()) != "") ? MOI.Name() : nothing
+    ]
+end
 
-MOI.canget(::LinQuadOptimizer, ::MOI.ListOfConstraintAttributesSet{F,S}) where F where S = true
-MOI.get(::LinQuadOptimizer, ::MOI.ListOfConstraintAttributesSet{F,S}) where F where S = MOI.AbstractConstraintAttribute[]
+function MOI.canget(::LinQuadOptimizer, ::MOI.ListOfConstraintAttributesSet{F,S}) where {F, S}
+    return true
+end
+function MOI.get(::LinQuadOptimizer, ::MOI.ListOfConstraintAttributesSet{F,S}) where {F, S}
+    return MOI.AbstractConstraintAttribute[]
+end

--- a/src/mockoptimizer.jl
+++ b/src/mockoptimizer.jl
@@ -182,6 +182,7 @@ function set_dual_status!(inner::MockLinQuadModel,input)
 end
 
 const SUPPORTED_OBJECTIVES = [
+    MOI.SingleVariable,
     LQOI.Linear,
     LQOI.Quad
 ]

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -51,7 +51,7 @@ function MOI.set!(model::LinQuadOptimizer,
     end
     model.obj_type = SingleVariableObjective
     model.single_obj_var = objective.variable
-    set_linear_objective!(model, [getcol(model, objective.variable)], [1.0])
+    set_linear_objective!(model, [get_column(model, objective.variable)], [1.0])
     set_constant_objective!(model, 0.0)
 end
 
@@ -75,7 +75,7 @@ function unsafe_set!(model::LinQuadOptimizer, ::MOI.ObjectiveFunction{F},
     model.obj_type = AffineObjective
     model.single_obj_var = nothing
     set_linear_objective!(model,
-        map(term -> getcol(model, term.variable_index), objective.terms),
+        map(term -> get_column(model, term.variable_index), objective.terms),
         map(term -> term.coefficient, objective.terms)
     )
     set_constant_objective!(model, objective.constant)
@@ -87,12 +87,12 @@ function MOI.set!(model::LinQuadOptimizer, attribute::MOI.ObjectiveFunction,
     model.obj_type = QuadraticObjective
     model.single_obj_var = nothing
     set_linear_objective!(model,
-        map(term -> getcol(model, term.variable_index), objective.affine_terms),
+        map(term -> get_column(model, term.variable_index), objective.affine_terms),
         map(term -> term.coefficient, objective.affine_terms)
     )
     columns_1, columns_2, coefficients = reduce_duplicates!(
-        map(term -> getcol(model, term.variable_index_1), objective.quadratic_terms),
-        map(term -> getcol(model, term.variable_index_2), objective.quadratic_terms),
+        map(term -> get_column(model, term.variable_index_1), objective.quadratic_terms),
+        map(term -> get_column(model, term.variable_index_2), objective.quadratic_terms),
         map(term -> term.coefficient, objective.quadratic_terms)
     )
     set_quadratic_objective!(model, columns_1, columns_2, coefficients)
@@ -189,7 +189,7 @@ function MOI.modify!(model::LinQuadOptimizer, ::MOI.ObjectiveFunction{F},
         model.obj_type = AffineObjective
         model.single_obj_var = nothing
     end
-    change_objective_coefficient!(model, getcol(model, change.variable),
+    change_objective_coefficient!(model, get_column(model, change.variable),
                                   change.new_coefficient)
 end
 

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -86,16 +86,9 @@ function MOI.set!(model::LinQuadOptimizer, attribute::MOI.ObjectiveFunction,
     __assert_objective__(model, attribute)
     model.obj_type = QuadraticObjective
     model.single_obj_var = nothing
-    set_linear_objective!(model,
-        map(term -> get_column(model, term.variable_index), objective.affine_terms),
-        map(term -> term.coefficient, objective.affine_terms)
-    )
-    columns_1, columns_2, coefficients = reduce_duplicates!(
-        map(term -> get_column(model, term.variable_index_1), objective.quadratic_terms),
-        map(term -> get_column(model, term.variable_index_2), objective.quadratic_terms),
-        map(term -> term.coefficient, objective.quadratic_terms)
-    )
-    set_quadratic_objective!(model, columns_1, columns_2, coefficients)
+    aff_cols, aff_coefs, quad_rows, quad_cols, quad_coefs = canonical_reduction(model, objective)
+    set_linear_objective!(model, aff_cols, aff_coefs)
+    set_quadratic_objective!(model, quad_rows, quad_cols, quad_coefs)
     set_constant_objective!(model, objective.constant)
 end
 

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -1,24 +1,29 @@
 #=
     The Objective Sense
 =#
+
 MOI.supports(::LinQuadOptimizer, ::MOI.ObjectiveSense) = true
-MOI.canget(m::LinQuadOptimizer, ::MOI.ObjectiveSense) = true
-MOI.get(m::LinQuadOptimizer,::MOI.ObjectiveSense) = m.obj_sense
-function MOI.set!(m::LinQuadOptimizer, ::MOI.ObjectiveSense, sense::MOI.OptimizationSense)
+MOI.canget(::LinQuadOptimizer, ::MOI.ObjectiveSense) = true
+MOI.get(model::LinQuadOptimizer,::MOI.ObjectiveSense) = model.obj_sense
+function MOI.set!(model::LinQuadOptimizer, ::MOI.ObjectiveSense,
+                  sense::MOI.OptimizationSense)
     if sense == MOI.MinSense
-        change_objective_sense!(m, :min)
-        m.obj_sense = MOI.MinSense
+        change_objective_sense!(model, :min)
+        model.obj_sense = MOI.MinSense
     elseif sense == MOI.MaxSense
-        change_objective_sense!(m, :max)
-        m.obj_sense = MOI.MaxSense
+        change_objective_sense!(model, :max)
+        model.obj_sense = MOI.MaxSense
     elseif sense == MOI.FeasibilitySense
         # we set the objective sense to :min, and the objective to 0.0
-        change_objective_sense!(m, :min)
-        unsafe_set!(m, MOI.ObjectiveFunction{Linear}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{Float64}[],0.0))
-        m.obj_type = AffineObjective
-        m.obj_sense = MOI.FeasibilitySense
+        change_objective_sense!(model, :min)
+        unsafe_set!(model, MOI.ObjectiveFunction{Linear}(),
+                    MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{Float64}[],
+                    0.0))
+        model.obj_type = AffineObjective
+        model.obj_sense = MOI.FeasibilitySense
     else
-        error("Sense $(sense) unknown.")
+        throw(MOI.CannotSetAttribute(MOI.ObjectiveSense,
+                                     "ObjectiveSense $(sense) not recognised."))
     end
 end
 
@@ -26,30 +31,34 @@ end
     The Objective Function
 =#
 
-function _assert_objective(model::LinQuadOptimizer, attribute::MOI.ObjectiveFunction{F}) where F
+function __assert_objective__(model::LinQuadOptimizer,
+                              attribute::MOI.ObjectiveFunction{F}) where F
     if MOI.get(model, MOI.ObjectiveSense()) == MOI.FeasibilitySense
         # it doesn't make sense to set an objective for a feasibility problem
-        error("Cannot set objective function when MOI.ObjectiveSense is MOI.FeasibilitySense.")
+        throw(MOI.CannotSetAttribute(attribute, "Cannot set $(attribute) when" *
+            " MOI.ObjectiveSense is MOI.FeasibilitySense."))
     elseif !(F in supported_objectives(model))
         throw(MOI.UnsupportedAttribute(attribute))
     end
 end
 
-function MOI.set!(m::LinQuadOptimizer, attr::MOI.ObjectiveFunction{MOI.SingleVariable}, var::MOI.SingleVariable)
-     _assert_objective(m, attr)
-    if m.obj_type == QuadraticObjective
-        set_quadratic_objective!(m, Int[], Int[], Float64[])
+function MOI.set!(model::LinQuadOptimizer,
+                  attribute::MOI.ObjectiveFunction{MOI.SingleVariable},
+                  objective::MOI.SingleVariable)
+     __assert_objective__(model, attribute)
+    if model.obj_type == QuadraticObjective
+        set_quadratic_objective!(model, Int[], Int[], Float64[])
     end
-    m.obj_type = SingleVariableObjective
-    m.single_obj_var = var.variable
-    set_linear_objective!(m, [getcol(m, var.variable)], [1.0])
-    set_constant_objective!(m, 0.0)
+    model.obj_type = SingleVariableObjective
+    model.single_obj_var = objective.variable
+    set_linear_objective!(model, [getcol(model, objective.variable)], [1.0])
+    set_constant_objective!(model, 0.0)
 end
 
-function MOI.set!(m::LinQuadOptimizer, attr::MOI.ObjectiveFunction{F}, objf::Linear) where F
-    _assert_objective(m, attr)
-    cobjf = MOIU.canonical(objf)
-    unsafe_set!(m, MOI.ObjectiveFunction{Linear}(), cobjf)
+function MOI.set!(model::LinQuadOptimizer, attribute::MOI.ObjectiveFunction{F},
+                  objective::Linear) where F
+    __assert_objective__(model, attribute)
+    unsafe_set!(model, MOI.ObjectiveFunction{Linear}(), MOIU.canonical(objective))
 end
 
 """
@@ -57,40 +66,37 @@ end
 
 Sets a linear objective function without cannonicalizing `objective`.
 """
-function unsafe_set!(m::LinQuadOptimizer, ::MOI.ObjectiveFunction{F}, objf::Linear) where F
-    if m.obj_type == QuadraticObjective
-        # previous objective was quadratic...
-        # zero quadratic part
-        set_quadratic_objective!(m, Int[], Int[], Float64[])
+function unsafe_set!(model::LinQuadOptimizer, ::MOI.ObjectiveFunction{F},
+                     objective::Linear) where F
+    if model.obj_type == QuadraticObjective
+        # previous objective was quadratic, so zero quadratic part
+        set_quadratic_objective!(model, Int[], Int[], Float64[])
     end
-    m.obj_type = AffineObjective
-    m.single_obj_var = nothing
-    columns = [getcol(m, term.variable_index) for term in objf.terms]
-    coefficients = [term.coefficient for term in objf.terms]
-    set_linear_objective!(m, columns, coefficients)
-    set_constant_objective!(m, objf.constant)
-    nothing
+    model.obj_type = AffineObjective
+    model.single_obj_var = nothing
+    set_linear_objective!(model,
+        map(term -> getcol(model, term.variable_index), objective.terms),
+        map(term -> term.coefficient, objective.terms)
+    )
+    set_constant_objective!(model, objective.constant)
 end
 
-function MOI.set!(m::LinQuadOptimizer, attr::MOI.ObjectiveFunction, objf::Quad)
-    _assert_objective(m, attr)
-    m.obj_type = QuadraticObjective
-    m.single_obj_var = nothing
-    columns = [getcol(m, term.variable_index) for term in objf.affine_terms]
-    coefficients = [term.coefficient for term in objf.affine_terms]
-    set_linear_objective!(m, columns, coefficients)
-
-    quadratic_columns_1 = [getcol(m, term.variable_index_1) for term in objf.quadratic_terms]
-    quadratic_columns_2 = [getcol(m, term.variable_index_2) for term in objf.quadratic_terms]
-    quadratic_coefficients = [term.coefficient for term in objf.quadratic_terms]
-    ri, ci, vi = reduce_duplicates!(
-        quadratic_columns_1,
-        quadratic_columns_2,
-        quadratic_coefficients
+function MOI.set!(model::LinQuadOptimizer, attribute::MOI.ObjectiveFunction,
+                  objective::Quad)
+    __assert_objective__(model, attribute)
+    model.obj_type = QuadraticObjective
+    model.single_obj_var = nothing
+    set_linear_objective!(model,
+        map(term -> getcol(model, term.variable_index), objective.affine_terms),
+        map(term -> term.coefficient, objective.affine_terms)
     )
-    set_quadratic_objective!(m, ri, ci, vi)
-    set_constant_objective!(m, objf.constant)
-    nothing
+    columns_1, columns_2, coefficients = reduce_duplicates!(
+        map(term -> getcol(model, term.variable_index_1), objective.quadratic_terms),
+        map(term -> getcol(model, term.variable_index_2), objective.quadratic_terms),
+        map(term -> term.coefficient, objective.quadratic_terms)
+    )
+    set_quadratic_objective!(model, columns_1, columns_2, coefficients)
+    set_constant_objective!(model, objective.constant)
 end
 
 #=
@@ -100,84 +106,98 @@ function MOI.supports(model::LinQuadOptimizer, ::MOI.ObjectiveFunction{F}) where
     return F in supported_objectives(model)
 end
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.ObjectiveFunction{MOI.SingleVariable}) = m.obj_type == SingleVariableObjective
-
-function MOI.get(m::LinQuadOptimizer, ::MOI.ObjectiveFunction{MOI.SingleVariable})
-    if m.obj_type != MOI.SingleVariable
-        error("Cannot get objective function.")
-    end
-    return MOI.SingleVariable(m.single_obj_var::MOI.VariableIndex)
+function MOI.canget(model::LinQuadOptimizer, ::MOI.ObjectiveFunction{MOI.SingleVariable})
+    return model.obj_type == SingleVariableObjective
 end
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.ObjectiveFunction{Linear}) = m.obj_type != QuadraticObjective
-
-function MOI.get(m::LinQuadOptimizer, ::MOI.ObjectiveFunction{Linear})
-    if m.obj_type == QuadraticObjective
-        error("Cannot get objective function.")
+function MOI.get(model::LinQuadOptimizer, ::MOI.ObjectiveFunction{MOI.SingleVariable})
+    if model.obj_type != MOI.SingleVariable
+        error("Cannot get SingleVariable objective function as the model has " *
+              " a $(model.obj_type) objective function.")
     end
-    variable_coefficients = zeros(length(m.variable_references))
-    get_linear_objective!(m, variable_coefficients)
+    return MOI.SingleVariable(model.single_obj_var::MOI.VariableIndex)
+end
+
+function MOI.canget(model::LinQuadOptimizer, ::MOI.ObjectiveFunction{Linear})
+    return model.obj_type != QuadraticObjective
+end
+
+function MOI.get(model::LinQuadOptimizer, ::MOI.ObjectiveFunction{Linear})
+    if model.obj_type == QuadraticObjective
+        error("Cannot get ScalarAffine objective function as the model has " *
+              " a quadratic objective function.")
+    end
+    variable_coefficients = zeros(length(model.variable_references))
+    get_linear_objective!(model, variable_coefficients)
     terms = map(
-        (v,c)->MOI.ScalarAffineTerm{Float64}(c,v),
-        m.variable_references,
+        (variable, coefficient) -> MOI.ScalarAffineTerm{Float64}(coefficient, variable),
+        model.variable_references,
         variable_coefficients
     )
-    Linear(terms, get_constant_objective(m))
+    return Linear(terms, get_constant_objective(model))
 end
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.ObjectiveFunction{Quad}) = m.obj_type == QuadraticObjective
+function MOI.canget(model::LinQuadOptimizer, ::MOI.ObjectiveFunction{Quad})
+    return model.obj_type == QuadraticObjective
+end
 
-function MOI.get(m::LinQuadOptimizer, ::MOI.ObjectiveFunction{Quad})
-    if m.obj_type != QuadraticObjective
-        error("Cannot get objective function.")
+function MOI.get(model::LinQuadOptimizer, ::MOI.ObjectiveFunction{Quad})
+    if model.obj_type != QuadraticObjective
+        error("Cannot get ScalarQuadratic objective function as the model has " *
+              " a $(model.obj_type) objective function.")
     end
-    variable_coefficients = zeros(length(m.variable_references))
-    get_linear_objective!(m, variable_coefficients)
+    variable_coefficients = zeros(length(model.variable_references))
+    get_linear_objective!(model, variable_coefficients)
     affine_terms = map(
-        (v,c)->MOI.ScalarAffineTerm{Float64}(c,v),
-        m.variable_references,
+        (variable, coefficient) -> MOI.ScalarAffineTerm{Float64}(coefficient, variable),
+        model.variable_references,
         variable_coefficients
     )
-    Q = get_quadratic_terms_objective(m)
+    Q = get_quadratic_terms_objective(model)
     rows = rowvals(Q)
-    vals = nonzeros(Q)
-    nrows, ncols = size(Q)
+    coefficients = nonzeros(Q)
     quadratic_terms = MOI.ScalarQuadraticTerm{Float64}[]
-    sizehint!(quadratic_terms, length(vals))
-    for i = 1:ncols
-        for j in nzrange(Q, i)
+    sizehint!(quadratic_terms, length(coefficients))
+    for (column, variable) in enumerate(model.variable_references)
+        for j in nzrange(Q, column)
             row = rows[j]
-            val = vals[j]
-            push!(quadratic_terms, MOI.ScalarQuadraticTerm{Float64}(val, m.variable_references[row], m.variable_references[i]))
+            push!(quadratic_terms,
+                  MOI.ScalarQuadraticTerm{Float64}(
+                      coefficients[j],
+                      model.variable_references[row],
+                      variable)
+            )
         end
     end
-    Quad(affine_terms, quadratic_terms, get_constant_objective(m))
+    return Quad(affine_terms, quadratic_terms, get_constant_objective(model))
 end
 
 #=
     Modify objective function
 =#
 
-function MOI.modify!(m::LinQuadOptimizer, ::MOI.ObjectiveFunction{F}, chg::MOI.ScalarCoefficientChange{Float64}) where F<:MOI.AbstractScalarFunction
-    if F <: MOI.ScalarQuadraticFunction && m.obj_type != QuadraticObjective
-        # TODO(odow): don't we want a descriptive error?
-        throw(MOI.UnsupportedObjectiveModification(chg))
-    elseif F <: MOI.ScalarAffineFunction && m.obj_type != AffineObjective
-        # TODO(odow): don't we want a descriptive error?
-        throw(MOI.UnsupportedObjectiveModification(chg))
+function MOI.modify!(model::LinQuadOptimizer, ::MOI.ObjectiveFunction{F},
+                     change::MOI.ScalarCoefficientChange{Float64}) where F<:MOI.AbstractScalarFunction
+    if F <: MOI.ScalarQuadraticFunction && model.obj_type != QuadraticObjective
+        throw(MOI.UnsupportedObjectiveModification(change,
+            "ObjectiveFunction is not a ScalarQuadraticFunction."))
+    elseif F <: MOI.ScalarAffineFunction && model.obj_type != AffineObjective
+        throw(MOI.UnsupportedObjectiveModification(change,
+            "ObjectiveFunction is not a ScalarAffineFunction."))
     end
-    if m.obj_type == SingleVariableObjective
-        m.obj_type = AffineObjective
-        m.single_obj_var = nothing
+    if model.obj_type == SingleVariableObjective
+        model.obj_type = AffineObjective
+        model.single_obj_var = nothing
     end
-    col = m.variable_mapping[chg.variable]
-    change_objective_coefficient!(m, col, chg.new_coefficient)
+    change_objective_coefficient!(model, getcol(model, change.variable),
+                                  change.new_coefficient)
 end
 
-function MOI.modify!(m::LinQuadOptimizer, ::MOI.ObjectiveFunction{F}, chg::MOI.ScalarConstantChange{Float64}) where F<:MOI.AbstractScalarFunction
+function MOI.modify!(model::LinQuadOptimizer, ::MOI.ObjectiveFunction{F},
+                     change::MOI.ScalarConstantChange{Float64}) where F<:MOI.AbstractScalarFunction
     if F == MOI.SingleVariable
-        # TODO(odow): don't we want a descriptive error?
-        throw(MOI.UnsupportedObjectiveModification(chg))
+        throw(MOI.UnsupportedObjectiveModification(change,
+            "ObjectiveFunction is a SingleVariable. Cannot change constant term."))
     end
-    set_constant_objective!(m, chg.new_constant)
+    set_constant_objective!(model, change.new_constant)
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -18,7 +18,7 @@ function MOI.optimize!(m::LinQuadOptimizer)
     m.dual_result_count = 0
 
     t = time()
-    if hasinteger(m)
+    if has_integer(m)
         solve_mip_problem!(m)
     elseif hasquadratic(m)
         solve_quadratic_problem!(m)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -142,7 +142,7 @@ end
 
 MOI.canget(::LinQuadOptimizer, ::MOI.VariablePrimal, ::Type{Vector{VarInd}}) = true
 function MOI.get(model::LinQuadOptimizer, ::MOI.VariablePrimal, indices::Vector{VarInd})
-    MOI.get.(Ref(model), MOI.VariablePrimal(), indices)
+    MOI.get.(Ref(model), Ref(MOI.VariablePrimal()), indices)
 end
 
 #=

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1,73 +1,66 @@
-function hasquadratic(m::LinQuadOptimizer)
-    (m.obj_type == QuadraticObjective) || (length(cmap(m).q_less_than) + length(cmap(m).q_greater_than) + length(cmap(m).q_equal_to) > 0)
+function has_quadratic(model::LinQuadOptimizer)
+    return model.obj_type == QuadraticObjective ||
+        length(cmap(model).q_less_than) > 0 ||
+        length(cmap(model).q_greater_than) > 0 ||
+        length(cmap(model).q_equal_to) > 0
 end
 
 #=
     Optimize the model
 =#
 
-function MOI.optimize!(m::LinQuadOptimizer)
+function MOI.optimize!(model::LinQuadOptimizer)
     # reset storage
-    fill!(m.variable_primal_solution, NaN)
-    fill!(m.variable_dual_solution, NaN)
-    fill!(m.constraint_primal_solution, NaN)
-    fill!(m.constraint_dual_solution, NaN)
-    m.primal_status = MOI.UnknownResultStatus
-    m.dual_status   = MOI.UnknownResultStatus
-    m.primal_result_count = 0
-    m.dual_result_count = 0
+    fill!(model.variable_primal_solution, NaN)
+    fill!(model.variable_dual_solution, NaN)
+    fill!(model.constraint_primal_solution, NaN)
+    fill!(model.constraint_dual_solution, NaN)
+    model.primal_status = MOI.UnknownResultStatus
+    model.dual_status   = MOI.UnknownResultStatus
+    model.primal_result_count = 0
+    model.dual_result_count = 0
 
-    t = time()
-    if has_integer(m)
-        solve_mip_problem!(m)
-    elseif hasquadratic(m)
-        solve_quadratic_problem!(m)
+    start_time = time()
+    if has_integer(model)
+        solve_mip_problem!(model)
+    elseif has_quadratic(model)
+        solve_quadratic_problem!(model)
     else
-        solve_linear_problem!(m)
+        solve_linear_problem!(model)
     end
-    m.solvetime = time() - t
+    model.solvetime = time() - start_time
 
     # termination_status
-    m.termination_status = get_termination_status(m)
-    m.primal_status = get_primal_status(m)
-    m.dual_status = get_dual_status(m)
+    model.termination_status = get_termination_status(model)
+    model.primal_status = get_primal_status(model)
+    model.dual_status = get_dual_status(model)
 
-    if m.primal_status in [MOI.FeasiblePoint, MOI.InfeasiblePoint]
-        # primal solution exists
-        get_variable_primal_solution!(m, m.variable_primal_solution)
-        get_linear_primal_solution!(m, m.constraint_primal_solution)
-        if hasquadratic(m)
-            get_quadratic_primal_solution!(m, m.qconstraint_primal_solution)
+    if model.primal_status in [MOI.FeasiblePoint, MOI.InfeasiblePoint]
+        get_variable_primal_solution!(model, model.variable_primal_solution)
+        get_linear_primal_solution!(model, model.constraint_primal_solution)
+        if has_quadratic(model)
+            get_quadratic_primal_solution!(model, model.qconstraint_primal_solution)
         end
-        m.primal_result_count = 1
-        # CPLEX can return infeasible points
-    elseif m.primal_status == MOI.InfeasibilityCertificate
-        get_unbounded_ray!(m, m.variable_primal_solution)
-        m.primal_result_count = 1
+        model.primal_result_count = 1
+    elseif model.primal_status == MOI.InfeasibilityCertificate
+        get_unbounded_ray!(model, model.variable_primal_solution)
+        model.primal_result_count = 1
     end
-    if m.dual_status in [MOI.FeasiblePoint, MOI.InfeasiblePoint]
-        # dual solution exists
-        get_variable_dual_solution!(m, m.variable_dual_solution)
-        get_linear_dual_solution!(m, m.constraint_dual_solution)
-        if hasquadratic(m)
-            get_quadratic_dual_solution!(m, m.qconstraint_dual_solution)
+    if model.dual_status in [MOI.FeasiblePoint, MOI.InfeasiblePoint]
+        get_variable_dual_solution!(model, model.variable_dual_solution)
+        get_linear_dual_solution!(model, model.constraint_dual_solution)
+        if has_quadratic(model)
+            get_quadratic_dual_solution!(model, model.qconstraint_dual_solution)
         end
-        m.dual_result_count = 1
-        # dual solution may not be feasible
-    elseif m.dual_status == MOI.InfeasibilityCertificate
-        get_farkas_dual!(m, m.constraint_dual_solution)
-        m.dual_result_count = 1
+        model.dual_result_count = 1
+    elseif model.dual_status == MOI.InfeasibilityCertificate
+        get_farkas_dual!(model, model.constraint_dual_solution)
+        model.dual_result_count = 1
     end
 
-    #=
-        CPLEX has the dual convention that the sign of the dual depends on the
-        optimization sense. This isn't the same as the MOI convention so we need
-        to correct that.
-    =#
-    # TODO
-    if MOI.get(m, MOI.ObjectiveSense()) == MOI.MaxSense
-        m.constraint_dual_solution *= -1
-        m.variable_dual_solution *= -1
+    if MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
+        model.constraint_dual_solution *= -1
+        model.variable_dual_solution *= -1
     end
 end
 
@@ -75,52 +68,64 @@ end
 #=
     Result Count
 =#
-MOI.canget(m::LinQuadOptimizer, ::MOI.ResultCount) = true
-function MOI.get(m::LinQuadOptimizer, ::MOI.ResultCount)
-    max(m.primal_result_count, m.dual_result_count)
+MOI.canget(::LinQuadOptimizer, ::MOI.ResultCount) = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.ResultCount)
+    return max(model.primal_result_count, model.dual_result_count)
 end
 
 #=
     Termination status
 =#
-MOI.canget(m::LinQuadOptimizer, ::MOI.TerminationStatus) = true
-function MOI.get(m::LinQuadOptimizer, ::MOI.TerminationStatus)
-    m.termination_status
+MOI.canget(::LinQuadOptimizer, ::MOI.TerminationStatus) = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.TerminationStatus)
+    return model.termination_status
 end
 
 #=
     Primal status
 =#
-MOI.canget(m::LinQuadOptimizer,  p::MOI.PrimalStatus) = m.primal_result_count >= p.N
-function MOI.get(m::LinQuadOptimizer, p::MOI.PrimalStatus)
-    return m.primal_status
+function MOI.canget(model::LinQuadOptimizer,  status::MOI.PrimalStatus)
+    if status.N != 1
+        error("Multiple primal statuses are not supported.")
+    end
+    return model.primal_result_count >= status.N
+end
+function MOI.get(model::LinQuadOptimizer, ::MOI.PrimalStatus)
+    return model.primal_status
 end
 
 #=
     Dual status
 =#
-MOI.canget(m::LinQuadOptimizer,  d::MOI.DualStatus) = m.dual_result_count >= d.N
-function MOI.get(m::LinQuadOptimizer, d::MOI.DualStatus)
-    return m.dual_status
+function MOI.canget(model::LinQuadOptimizer,  status::MOI.DualStatus)
+    if status.N != 1
+        error("Multiple dual statuses are not supported.")
+    end
+    return model.dual_result_count >= status.N
+end
+function MOI.get(model::LinQuadOptimizer, ::MOI.DualStatus)
+    return model.dual_status
 end
 
 #=
     Objective Value
 =#
-MOI.canget(m::LinQuadOptimizer, attr::MOI.ObjectiveValue) =  attr.resultindex == 1
-function MOI.get(m::LinQuadOptimizer, attr::MOI.ObjectiveValue)
+function MOI.canget(::LinQuadOptimizer, attr::MOI.ObjectiveValue)
+    return attr.resultindex == 1
+end
+function MOI.get(model::LinQuadOptimizer, attr::MOI.ObjectiveValue)
     if attr.resultindex == 1
         # Note: we add m.objective_constant here to account for any constant
         # term which was not passed to the solver itself (and which therefore
         # would not be accounted for in `get_objective_value(m)`. We do *not*
-        # call `get_constant_objective(m)` because that would also pull
-        # any constants which were passed to the solver, resulting those
-        # constants being counted twice. This confusion will be alleviated
-        # when all LQOI solvers implement `get_constant_objective()` and
+        # call `get_constant_objective(m)` because that would also pull any
+        # constants which were passed to the solver, resulting those constants
+        # being counted twice. This confusion will be alleviated when all LQOI
+        # solvers implement `get_constant_objective()` and
         # `set_constant_objective!()` by actually passing the relevant constants
-        # to the solvers, at which point we can just get rid of m.objective_constant
-        # entirely.
-        get_objective_value(m) + m.objective_constant
+        # to the solvers, at which point we can just get rid of
+        # m.objective_constant entirely.
+        return get_objective_value(model) + model.objective_constant
     else
         error("Unable to access multiple objective values")
     end
@@ -129,76 +134,73 @@ end
 #=
     Variable Primal solution
 =#
-MOI.canget(m::LinQuadOptimizer, ::MOI.VariablePrimal, ::Type{VarInd}) = true
-
-function MOI.get(m::LinQuadOptimizer, ::MOI.VariablePrimal, v::VarInd)
-    col = m.variable_mapping[v]
-    return m.variable_primal_solution[col]
+MOI.canget(::LinQuadOptimizer, ::MOI.VariablePrimal, ::Type{VarInd}) = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.VariablePrimal, index::VarInd)
+    column = get_column(model, index)
+    return model.variable_primal_solution[column]
 end
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.VariablePrimal, ::Type{Vector{VarInd}}) = true
-
-function MOI.get(m::LinQuadOptimizer, ::MOI.VariablePrimal, v::Vector{VarInd})
-    MOI.get.(Ref(m), MOI.VariablePrimal(), v)
+MOI.canget(::LinQuadOptimizer, ::MOI.VariablePrimal, ::Type{Vector{VarInd}}) = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.VariablePrimal, indices::Vector{VarInd})
+    MOI.get.(Ref(model), MOI.VariablePrimal(), indices)
 end
 
 #=
     Variable Dual solution
 =#
-isbinding(set::LE, value::Float64) = isapprox(set.upper, value)
-isbinding(set::GE, value::Float64) = isapprox(set.lower, value)
-isbinding(set::EQ, value::Float64) = isapprox(set.value, value)
-isbinding(set::IV, value::Float64) = isapprox(set.lower, value) || isapprox(set.upper, value)
+"""
+    is_binding(set, value::Float64)
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintDual, ::Type{SVCI{S}}) where S <: LinSets = true
+Return true if `value` is an extreme point of the set `set`.
+"""
+is_binding(set::LE, value::Float64) = isapprox(set.upper, value)
+is_binding(set::GE, value::Float64) = isapprox(set.lower, value)
+is_binding(set::EQ, value::Float64) = isapprox(set.value, value)
+is_binding(set::IV, value::Float64) = isapprox(set.lower, value) || isapprox(set.upper, value)
 
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintDual, c::SVCI{<: LinSets})
-    vref = m[c]
-    col = m.variable_mapping[vref]
+function MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintDual, ::Type{SVCI{S}}) where S <: LinSets
+    return true
+end
+
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintDual, index::SVCI{<: LinSets})
+    column = get_column(model, model[index])
     # the variable reduced cost is only the constriant dual if the bound is active.
-    set = MOI.get(m, MOI.ConstraintSet(), c)
-    solval = m.variable_primal_solution[col]
-    if isbinding(set, solval)
-        return m.variable_dual_solution[col]
+    set = MOI.get(model, MOI.ConstraintSet(), index)
+    primal_value = model.variable_primal_solution[column]
+    if is_binding(set, primal_value)
+        return model.variable_dual_solution[column]
     else
         return 0.0
     end
 end
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintDual, ::Type{VVCI{S}}) where S <: Union{MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives} = true
-
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintDual, c::VVCI{<: Union{MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives}})
-    rowrefs = m[c]
-    out = Float64[]
-    sizehint!(out, length(rowrefs))
-    for ref in rowrefs
-        push!(out, m.constraint_dual_solution[ref])
-    end
-    return out
+function MOI.canget(s::LinQuadOptimizer, ::MOI.ConstraintDual,
+                    ::Type{VVCI{S}}) where S <: Union{MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives}
+    return true
+end
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintDual, index::VVCI{<: Union{MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives}})
+    return [model.constraint_dual_solution[row] for row in model[index]]
 end
 
 #=
     Variable Bound Primal solution
 =#
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintPrimal, ::Type{SVCI{S}}) where S <: LinSets = true
+MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintPrimal, ::Type{SVCI{S}}) where S <: LinSets = true
 
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintPrimal, c::SVCI{<: LinSets})
-    vref = m[c]
-    col = m.variable_mapping[vref]
-    return m.variable_primal_solution[col]
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintPrimal, index::SVCI{<: LinSets})
+    column = get_column(model, model[index])
+    return model.variable_primal_solution[column]
 end
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintPrimal, ::Type{VVCI{S}}) where S <: Union{MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives} = true
+function MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintPrimal,
+                   ::Type{VVCI{S}}) where S <: Union{MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives}
+    return true
+end
 
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintPrimal, c::VVCI{<: Union{MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives}})
-    rowrefs = m[c]
-    out = Float64[]
-    sizehint!(out, length(rowrefs))
-    for ref in rowrefs
-        push!(out, m.constraint_primal_solution[ref])
-    end
-    return out
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintPrimal,
+                 index::VVCI{<: Union{MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives}})
+    return [model.constraint_primal_solution[row] for row in model[index]]
 end
 
 #=
@@ -207,85 +209,102 @@ end
 
 MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintPrimal, ::Type{LCI{S}}) where S <: LinSets = true
 
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintPrimal, c::LCI{<: LinSets})
-    row = m[c]
-    return m.constraint_primal_solution[row]+m.constraint_constant[row]
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintPrimal, index::LCI{<: LinSets})
+    row = model[index]
+    return model.constraint_primal_solution[row] + model.constraint_constant[row]
 end
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintPrimal, ::Type{QCI{S}}) where S <: LinSets = true
+MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintPrimal, ::Type{QCI{S}}) where S <: LinSets = true
 
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintPrimal, c::QCI{<: LinSets})
-    row = m[c]
-    return m.qconstraint_primal_solution[row]#+m.qconstraint_constant[row]
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintPrimal, index::QCI{<: LinSets})
+    row = model[index]
+    return model.qconstraint_primal_solution[row]
 end
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintPrimal, ::Type{VLCI{S}}) where S <: Union{MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives} = true
+MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintPrimal, ::Type{VLCI{S}}) where S <: Union{MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives} = true
 
 # vector valued constraint duals
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintPrimal, c::VLCI{<: Union{MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives}})
-    row = m[c]
-    return m.constraint_primal_solution[row]+m.constraint_constant[row]
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintPrimal, index::VLCI{<: Union{MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives}})
+    row = model[index]
+    return model.constraint_primal_solution[row] + model.constraint_constant[row]
 end
 
 #=
     Constraint Dual solution
 =#
 
-_checkdualsense(::LCI{LE}, dual) = dual <= 0.0
-_checkdualsense(::LCI{GE}, dual) = dual >= 0.0
-_checkdualsense(::LCI{IV}, dual) = true
-_checkdualsense(::LCI{EQ}, dual) = true
+__assert_dual_sense__(::LCI{LE}, dual) = @assert dual <= 0.0
+__assert_dual_sense__(::LCI{GE}, dual) = @assert dual >= 0.0
+__assert_dual_sense__(::LCI{IV}, dual) = nothing
+__assert_dual_sense__(::LCI{EQ}, dual) = nothing
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintDual, ::Type{LCI{S}}) where S <: LinSets = true
+MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintDual, ::Type{LCI{S}}) where S <: LinSets = true
 
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintDual, c::LCI{<: LinSets})
-    row = m[c]
-    dual = m.constraint_dual_solution[row]
-    @assert _checkdualsense(c, dual)
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintDual, index::LCI{<: LinSets})
+    row = model[index]
+    dual = model.constraint_dual_solution[row]
+    __assert_dual_sense__(index, dual)
     return dual
 end
 
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintDual, ::Type{QCI{S}}) where S <: LinSets = true
+MOI.canget(model::LinQuadOptimizer, ::MOI.ConstraintDual, ::Type{QCI{S}}) where S <: LinSets = true
 
-function MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintDual, c::QCI{<: LinSets})
-    row = m[c]
-    return m.qconstraint_dual_solution[row]#+m.qconstraint_constant[row]
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintDual, index::QCI{<: LinSets})
+    row = model[index]
+    return model.qconstraint_dual_solution[row]
 end
 
 
 # vector valued constraint duals
-MOI.canget(m::LinQuadOptimizer, ::MOI.ConstraintDual, ::Type{VLCI{S}}) where S <: Union{MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives} = true
+MOI.canget(::LinQuadOptimizer, ::MOI.ConstraintDual, ::Type{VLCI{S}}) where S <: Union{MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives} = true
 
-MOI.get(m::LinQuadOptimizer, ::MOI.ConstraintDual, c::VLCI{<: Union{MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives}}) = m.constraint_dual_solution[m[c]]
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintDual, index::VLCI{<: Union{MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives}})
+    rows = model[index]
+    return model.constraint_dual_solution[rows]
+end
 
 #=
     Solution Attributes
 =#
 
-MOI.supports(model::LinQuadOptimizer, ::MOI.ObjectiveBound) = true
-MOI.canget(m::LinQuadOptimizer, ::MOI.ObjectiveBound) = true
-MOI.get(model::LinQuadOptimizer, ::MOI.ObjectiveBound) = get_objective_bound(model)
+MOI.supports(::LinQuadOptimizer, ::MOI.ObjectiveBound) = true
+MOI.canget(::LinQuadOptimizer, ::MOI.ObjectiveBound) = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.ObjectiveBound)
+    return get_objective_bound(model)
+end
 
-MOI.supports(model::LinQuadOptimizer, ::MOI.RelativeGap) = true
-MOI.canget(m::LinQuadOptimizer, ::MOI.RelativeGap) = true
-MOI.get(model::LinQuadOptimizer, ::MOI.RelativeGap) = get_relative_mip_gap(model)
+MOI.supports(::LinQuadOptimizer, ::MOI.RelativeGap) = true
+MOI.canget(::LinQuadOptimizer, ::MOI.RelativeGap) = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.RelativeGap)
+    return get_relative_mip_gap(model)
+end
 
-MOI.supports(model::LinQuadOptimizer, ::MOI.SolveTime) = true
-MOI.canget(m::LinQuadOptimizer, ::MOI.SolveTime) = true
-MOI.get(model::LinQuadOptimizer, ::MOI.SolveTime) = model.solvetime
+MOI.supports(::LinQuadOptimizer, ::MOI.SolveTime) = true
+MOI.canget(::LinQuadOptimizer, ::MOI.SolveTime) = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.SolveTime)
+    return model.solvetime
+end
 
-MOI.supports(model::LinQuadOptimizer, ::MOI.SimplexIterations) = true
-MOI.canget(m::LinQuadOptimizer, ::MOI.SimplexIterations) = true
-MOI.get(model::LinQuadOptimizer, ::MOI.SimplexIterations) = get_iteration_count(model)
+MOI.supports(::LinQuadOptimizer, ::MOI.SimplexIterations) = true
+MOI.canget(::LinQuadOptimizer, ::MOI.SimplexIterations) = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.SimplexIterations)
+    return get_iteration_count(model)
+end
 
-MOI.supports(model::LinQuadOptimizer, ::MOI.BarrierIterations) = true
-MOI.canget(m::LinQuadOptimizer, ::MOI.BarrierIterations) = true
-MOI.get(model::LinQuadOptimizer, ::MOI.BarrierIterations) = get_barrier_iterations(model)
+MOI.supports(::LinQuadOptimizer, ::MOI.BarrierIterations) = true
+MOI.canget(::LinQuadOptimizer, ::MOI.BarrierIterations) = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.BarrierIterations)
+    return get_barrier_iterations(model)
+end
 
-MOI.supports(model::LinQuadOptimizer, ::MOI.NodeCount) = true
-MOI.canget(m::LinQuadOptimizer, ::MOI.NodeCount) = true
-MOI.get(model::LinQuadOptimizer, ::MOI.NodeCount) = get_node_count(model)
+MOI.supports(::LinQuadOptimizer, ::MOI.NodeCount) = true
+MOI.canget(::LinQuadOptimizer, ::MOI.NodeCount) = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.NodeCount)
+    return get_node_count(model)
+end
 
-MOI.supports(model::LinQuadOptimizer, ::MOI.RawSolver) = true
-MOI.canget(m::LinQuadOptimizer, ::MOI.RawSolver) = true
-MOI.get(model::LinQuadOptimizer, ::MOI.RawSolver) = model
+MOI.supports(::LinQuadOptimizer, ::MOI.RawSolver) = true
+MOI.canget(::LinQuadOptimizer, ::MOI.RawSolver) = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.RawSolver)
+    return model
+end

--- a/src/solver_interface.jl
+++ b/src/solver_interface.jl
@@ -82,7 +82,6 @@ Initializes a model given a model type `M` and an `env` that might be a `nothing
 for some solvers.
 """
 function LinearQuadraticModel end
-@deprecate LinQuadModel LinearQuadraticModel
 
 """
     supported_constraints(m)::Vector{
@@ -94,7 +93,6 @@ Get a list of supported constraint types in the model `m`.
 For example, `[(LQOI.Linear, LQOI.EQ)]`
 """
 function supported_constraints end
-@deprecate lqs_supported_constraints supported_constraints
 
 """
     supported_objectives(m)::Vector{MOI.AbstractScalarFunction}
@@ -104,7 +102,6 @@ Get a list of supported objective types in the model `m`.
 For example, `[LQOI.Linear, LQOI.Quad]`
 """
 function supported_objectives end
-@deprecate lqs_supported_objectives supported_objectives
 
 # Constraints
 
@@ -116,7 +113,6 @@ is given by `backend_type(m, Val{:Upperbound}())`. The sense
 of the lowerbound is given by `backend_type(m, Val{:Lowerbound}())`
 """
 function change_variable_bounds! end
-@deprecate lqs_chgbds! change_variable_bounds!
 
 """
     get_variable_lowerbound(m, col::Int)::Float64
@@ -124,7 +120,6 @@ function change_variable_bounds! end
 Get the lower bound of the variable in 1-indexed column `col` of the model `m`.
 """
 function get_variable_lowerbound end
-@deprecate lqs_getlb get_variable_lowerbound
 
 """
     get_variable_upperbound(m, col::Int)::Float64
@@ -132,7 +127,6 @@ function get_variable_lowerbound end
 Get the upper bound of the variable in 1-indexed column `col` of the model `m`.
 """
 function get_variable_upperbound end
-@deprecate lqs_getub get_variable_upperbound
 
 """
     get_number_linear_constraints(m)::Int
@@ -140,7 +134,6 @@ function get_variable_upperbound end
 Get the number of linear constraints in the model `m`.
 """
 function get_number_linear_constraints end
-@deprecate lqs_getnumrows get_number_linear_constraints
 
 """
     add_linear_constraints!(m, A::CSRMatrix{Float64},
@@ -157,7 +150,6 @@ instead.
 See also: `LinQuadOptInterface.CSRMatrix`.
 """
 function add_linear_constraints! end
-@deprecate lqs_addrows! add_linear_constraints!
 
 """
     add_ranged_constraints!(m, A::CSRMatrix{Float64},
@@ -188,7 +180,6 @@ Get the right-hand side of the linear constraint in the 1-indexed row `row` in
 the model `m`.
 """
 function get_rhs end
-@deprecate lqs_getrhs get_rhs
 
 """
     get_range(m, row::Int)::Tuple{Float64,Float64}
@@ -204,7 +195,6 @@ Get the linear component of the constraint in the 1-indexed row `row` in
 the model `m`. Returns a tuple of `(cols, vals)`.
 """
 function get_linear_constraint end
-@deprecate lqs_getrows get_linear_constraint
 
 """
     change_matrix_coefficient!(m, row, col, coef)
@@ -213,7 +203,6 @@ Set the linear coefficient of the variable in column `col`, constraint `row` to
 `coef`.
 """
 function change_matrix_coefficient! end
-@deprecate lqs_chgcoef! change_matrix_coefficient!
 
 """
 change_objective_coefficient!(m, col, coef)
@@ -236,7 +225,6 @@ Delete the linear constraints `start_row`, `start_row+1`, ..., `end_row` from
 the model `m`.
 """
 function delete_linear_constraints! end
-@deprecate lqs_delrows! delete_linear_constraints!
 
 """
     delete_quadratic_constraints!(m, start_row::Int, end_row::Int)::Nothing
@@ -255,7 +243,6 @@ Change the variable types. Type is the output of one of:
  - `backend_type(m, Val{:Continuous}())`, for continuous variables.
 """
 function change_variable_types! end
-@deprecate lqs_chgctype! change_variable_types!
 
 """
     change_linear_constraint_sense!(m, rows::Vector{Int}, sense::Vector{Symbol})::Nothing
@@ -268,7 +255,6 @@ is the corresponding set for the row `rows[i]`.
 `Interval` constraints require a call to `change_range_value!`.
 """
 function change_linear_constraint_sense! end
-@deprecate lqs_chgsense! change_linear_constraint_sense!
 
 """
     make_problem_type_integer(m)::Nothing
@@ -278,7 +264,6 @@ If an explicit call is needed to change the problem type integer (e.g., CPLEX).
 function make_problem_type_integer(m::LinQuadOptimizer)
     nothing  # default
 end
-@deprecate lqs_make_problem_type_integer make_problem_type_integer
 
 """
     make_problem_type_continuous(m)::Nothing
@@ -288,7 +273,6 @@ If an explicit call is needed to change the problem type continuous (e.g., CPLEX
 function make_problem_type_continuous(m::LinQuadOptimizer)
     nothing  # default
 end
-@deprecate lqs_make_problem_type_continuous make_problem_type_continuous
 
 """
     add_sos_constraint!(m, cols::Vector{Int}, vals::Vector{Float64}, typ::Symbol)::Nothing
@@ -296,7 +280,6 @@ end
 Add the SOS constraint to the model `m`. `typ` is either `:SOS1` or `:SOS2`.
 """
 function add_sos_constraint! end
-@deprecate lqs_addsos! add_sos_constraint!
 
 """
     delete_sos!(m, start_idx::Int, end_idx::Int)::Nothing
@@ -305,7 +288,6 @@ Delete the SOS constraints `start_idx`, `start_idx+1`, ..., `end_idx` from
 the model `m`.
 """
 function delete_sos! end
-@deprecate lqs_delsos! delete_sos!
 
 """
     get_sos_constraint(m, idx::Int)::Tuple{Vector{Int}, Vector{Float64}, Symbol}
@@ -321,7 +303,6 @@ function get_sos_constraint end
 Get the number of quadratic constraints in the model `m`.
 """
 function get_number_quadratic_constraints end
-@deprecate lqs_getnumqcosntrs get_number_quadratic_constraints
 
 """
     add_quadratic_constraint!(m, cols::Vector{Int}, coefs::Vector{Float64}, rhs::Float64,
@@ -354,7 +335,6 @@ Set the quadratic component of the objective. Arguments given in triplet form
 for the Q matrix in `0.5 x' Q x`.
 """
 function set_quadratic_objective! end
-@deprecate lqs_copyquad! set_quadratic_objective!
 
 """
     get_quadratic_constraint(m, row::Int)::Tuple{Vector{Int}, Vector{Float64}, SparseMatrixCSC{Float64,Int64}}
@@ -378,7 +358,6 @@ function get_quadratic_rhs end
 Set the linear component of the objective.
 """
 function set_linear_objective! end
-@deprecate lqs_chgobj! set_linear_objective!
 
 """
     change_objective_sense!(m, sense::Symbol)::Nothing
@@ -387,8 +366,6 @@ Change the optimization sense of the model `m` to `sense`. `sense` must be
 `:min` or `:max`.
 """
 function change_objective_sense! end
-@deprecate lqs_chgobjsen! change_objective_sense!
-
 
 """
     get_constant_objective(m)::Float64
@@ -404,7 +381,6 @@ Get the linear coefficients of the objective and store
 in `x`.
 """
 function get_linear_objective! end
-@deprecate lqs_getobj get_linear_objective!
 
 """
     get_quadratic_terms_objective(m)::SparseMatrixCSC{Float64,Int64}
@@ -419,7 +395,6 @@ function get_quadratic_terms_objective end
 Get the optimization sense of the model `m`.
 """
 function get_objectivesense end
-@deprecate lqs_getobjsen get_objectivesense
 
 """
     solve_mip_problem!(m)::Nothing
@@ -427,7 +402,6 @@ function get_objectivesense end
 Solve a mixed-integer model `m`.
 """
 function solve_mip_problem! end
-@deprecate lqs_mipopt! solve_mip_problem!
 
 """
     solve_quadratic_problem!(m)::Nothing
@@ -435,7 +409,6 @@ function solve_mip_problem! end
 Solve a model `m` with quadratic components.
 """
 function solve_quadratic_problem! end
-@deprecate lqs_qpopt! solve_quadratic_problem!
 
 """
     solve_linear_problem!(m)::Nothing
@@ -443,7 +416,6 @@ function solve_quadratic_problem! end
 Solve a linear program `m`.
 """
 function solve_linear_problem! end
-@deprecate lqs_lpopt! solve_linear_problem!
 
 """
     get_variable_primal_solution!(m, x::Vector{Float64})
@@ -452,7 +424,6 @@ Get the primal solution for the variables in the model `m`, and
 store in `x`. `x`must have one element for each variable.
 """
 function get_variable_primal_solution! end
-@deprecate lqs_getx! get_variable_primal_solution!
 
 """
     get_linear_primal_solution!(m, x::Vector{Float64})
@@ -462,7 +433,6 @@ constraint primal `a'x` for each constraint, and store in `x`.
 `x` must have one element for each linear constraint.
 """
 function get_linear_primal_solution! end
-@deprecate lqs_getax! get_linear_primal_solution!
 
 """
     get_quadratic_primal_solution!(m, x::Vector{Float64})
@@ -472,7 +442,6 @@ get the constraint primal `a'x + x'Qx` for each constraint, and store in `x`.
 `x` must have one element for each quadratic constraint.
 """
 function get_quadratic_primal_solution! end
-@deprecate lqs_getqcax! get_quadratic_primal_solution!
 
 """
     get_variable_dual_solution!(m, x::Vector{Float64})
@@ -481,7 +450,6 @@ Get the dual solution (reduced-costs) for the variables in the model `m`, and
 store in `x`. `x`must have one element for each variable.
 """
 function get_variable_dual_solution! end
-@deprecate lqs_getdj! get_variable_dual_solution!
 
 """
     get_linear_dual_solution!(m, x::Vector{Float64})
@@ -490,7 +458,6 @@ Get the dual solution for the linear constraints in the model `m`, and
 store in `x`. `x`must have one element for each linear constraint.
 """
 function get_linear_dual_solution! end
-@deprecate lqs_getpi! get_linear_dual_solution!
 
 """
     get_quadratic_dual_solution!(m, x::Vector{Float64})
@@ -499,7 +466,6 @@ Get the dual solution for the quadratic constraints in the model `m`, and
 store in `x`. `x`must have one element for each quadratic constraint.
 """
 function get_quadratic_dual_solution! end
-@deprecate lqs_getqcpi! get_quadratic_dual_solution!
 
 """
     get_objective_value(m)
@@ -507,7 +473,6 @@ function get_quadratic_dual_solution! end
 Get the objective value of the solved model `m`.
 """
 function get_objective_value end
-@deprecate lqs_getobjval get_objective_value
 
 """
     get_objective_bound(m)
@@ -515,7 +480,6 @@ function get_objective_value end
 Get the objective bound of the model `m`.
 """
 function get_objective_bound end
-@deprecate lqs_getbestobjval get_objective_bound
 
 """
     get_relative_mip_gap(m)
@@ -523,7 +487,6 @@ function get_objective_bound end
 Get the relative MIP gap of the solved model `m`.
 """
 function get_relative_mip_gap end
-@deprecate lqs_getmiprelgap get_relative_mip_gap
 
 """
     get_iteration_count(m)
@@ -532,7 +495,6 @@ Get the number of simplex iterations performed during the most recent
 optimization of the model `m`.
 """
 function get_iteration_count end
-@deprecate lqs_getitcnt get_iteration_count
 
 """
     get_barrier_iterations(m)
@@ -541,7 +503,6 @@ Get the number of barrier iterations performed during the most recent
 optimization of the model `m`.
 """
 function get_barrier_iterations end
-@deprecate lqs_getbaritcnt get_barrier_iterations
 
 """
     get_node_count(m)
@@ -550,7 +511,6 @@ Get the number of branch-and-cut nodes expolored during the most recent
 optimization of the model `m`.
 """
 function get_node_count end
-@deprecate lqs_getnodecnt get_node_count
 
 """
     get_farkas_dual!(m, x::Vector{Float64})
@@ -560,7 +520,6 @@ constraints in the model `m`, and store in `x`. `x`must have one element for
 each linear constraint.
 """
 function get_farkas_dual! end
-@deprecate lqs_dualfarkas! get_farkas_dual!
 
 """
     get_unbounded_ray!(m, x::Vector{Float64})
@@ -570,7 +529,6 @@ constraints in the model `m`, and store in `x`. `x`must have one element for
 each variable.
 """
 function get_unbounded_ray! end
-@deprecate lqs_getray! get_unbounded_ray!
 
 """
     get_termination_status(m)
@@ -578,7 +536,6 @@ function get_unbounded_ray! end
 Get the termination status of the model `m`.
 """
 function get_termination_status end
-@deprecate lqs_terminationstatus get_termination_status
 
 """
     get_primal_status(m)
@@ -586,7 +543,6 @@ function get_termination_status end
 Get the primal status of the model `m`.
 """
 function get_primal_status end
-@deprecate lqs_primalstatus get_primal_status
 
 """
     get_dual_status(m)
@@ -594,7 +550,6 @@ function get_primal_status end
 Get the dual status of the model `m`.
 """
 function get_dual_status end
-@deprecate lqs_dualstatus get_dual_status
 
 """
     get_number_variables(m)::Int
@@ -602,7 +557,6 @@ function get_dual_status end
 Get the number of variables in the model `m`.
 """
 function get_number_variables end
-@deprecate lqs_getnumcols get_number_variables
 
 """
     add_variables!(m, n::Int)::Nothing
@@ -610,7 +564,6 @@ function get_number_variables end
 Add `n` new variables to the model `m`.
 """
 function add_variables! end
-@deprecate lqs_newcols! add_variables!
 
 """
     delete_variables!(m, start_col::Int, end_col::Int)::Nothing
@@ -618,7 +571,6 @@ function add_variables! end
 Delete the columns `start_col`, `start_col+1`, ..., `end_col` from the model `m`.
 """
 function delete_variables! end
-@deprecate lqs_delcols! delete_variables!
 
 """
     add_mip_starts!(m, cols::Vector{Int}, x::Vector{Float64})::Nothing
@@ -626,4 +578,3 @@ function delete_variables! end
 Add the MIP start `x` for the variables in the columns `cols` of the model `m`.
 """
 function add_mip_starts! end
-@deprecate lqs_addmipstarts! add_mip_starts!

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1,113 +1,131 @@
 #=
     Helper functions
 =#
-getcol(m::LinQuadOptimizer, ref::VarInd) = m.variable_mapping[ref]
-getcol(m::LinQuadOptimizer, v::SinVar) = getcol(m, v.variable)
+"""
+    get_column(model::LinQuadOptimizer, index::MOI.VariableIndex)
+
+Return the column of the variable `index` in `model`.
+"""
+function get_column(model::LinQuadOptimizer, index::VarInd)
+    return model.variable_mapping[index]
+end
+
+"""
+    get_column(model::LinQuadOptimizer, variable::MOI.SingleVariable)
+
+Return the column of the variable inside a `MOI.SingleVariable` function in
+`model`.
+"""
+function get_column(model::LinQuadOptimizer, variable::SinVar)
+    return get_column(model, variable.variable)
+end
 
 #=
     Get variable names
 =#
-MOI.supports(model::LinQuadOptimizer, ::MOI.VariableName, ::Type{VarInd}) = true
-MOI.canget(m::LinQuadOptimizer, ::MOI.VariableName, ::Type{VarInd}) = true
-function MOI.get(m::LinQuadOptimizer, ::MOI.VariableName, ref::VarInd)
-    if haskey(m.variable_names, ref)
-        m.variable_names[ref]
+MOI.supports(::LinQuadOptimizer, ::MOI.VariableName, ::Type{VarInd}) = true
+MOI.canget(::LinQuadOptimizer, ::MOI.VariableName, ::Type{VarInd}) = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.VariableName, index::VarInd)
+    if haskey(model.variable_names, index)
+        return model.variable_names[index]
     else
-        ""
+        return ""
     end
 end
 
-function MOI.set!(m::LinQuadOptimizer, ::MOI.VariableName, ref::VarInd, name::String)
-    if haskey(m.variable_names_rev, name)
-        if m.variable_names_rev[name] != ref
+function MOI.set!(model::LinQuadOptimizer, ::MOI.VariableName, index::VarInd, name::String)
+    if haskey(model.variable_names_rev, name)
+        if model.variable_names_rev[name] != index
             error("Duplicate variable name: $(name)")
         end
     elseif name != ""
-        if haskey(m.variable_names, ref)
+        if haskey(model.variable_names, index)
             # we're renaming an existing variable
-            old_name = m.variable_names[ref]
-            delete!(m.variable_names_rev, old_name)
+            old_name = model.variable_names[index]
+            delete!(model.variable_names_rev, old_name)
         end
-        m.variable_names[ref] = name
-        m.variable_names_rev[name] = ref
+        model.variable_names[index] = name
+        model.variable_names_rev[name] = index
     end
+    return nothing
 end
 
 #=
     Get variable by name
 =#
-function MOI.canget(m::LinQuadOptimizer, ::Type{MOI.VariableIndex}, name::String)
-    haskey(m.variable_names_rev, name)
+function MOI.canget(model::LinQuadOptimizer, ::Type{MOI.VariableIndex}, name::String)
+    return haskey(model.variable_names_rev, name)
 end
-function MOI.get(m::LinQuadOptimizer, ::Type{MOI.VariableIndex}, name::String)
-    return m.variable_names_rev[name]
+function MOI.get(model::LinQuadOptimizer, ::Type{MOI.VariableIndex}, name::String)
+    return model.variable_names_rev[name]
 end
 
 #=
     Get number of variables
 =#
-MOI.canget(m::LinQuadOptimizer, ::MOI.NumberOfVariables) = true
-function MOI.get(m::LinQuadOptimizer, ::MOI.NumberOfVariables)
-    # TODO(odow): just return length(m.variable_references)?
-    return get_number_variables(m)
+MOI.canget(::LinQuadOptimizer, ::MOI.NumberOfVariables) = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.NumberOfVariables)
+    # TODO(odow): work out why this is not the same as
+    # length(model.variable_references)
+    return get_number_variables(model)
 end
 
 #=
     List of Variable References
 =#
-MOI.canget(m::LinQuadOptimizer, ::MOI.ListOfVariableIndices) = true
-function MOI.get(m::LinQuadOptimizer, ::MOI.ListOfVariableIndices)
-    return m.variable_references
+MOI.canget(::LinQuadOptimizer, ::MOI.ListOfVariableIndices) = true
+function MOI.get(model::LinQuadOptimizer, ::MOI.ListOfVariableIndices)
+    return model.variable_references
 end
 
 #=
     Add a single variable
 =#
 
-function MOI.addvariable!(m::LinQuadOptimizer)
-    add_variables!(m, 1)
+function MOI.addvariable!(model::LinQuadOptimizer)
+    add_variables!(model, 1)
     # assumes we add columns linearly
-    m.last_variable_reference += 1
-    ref = VarInd(m.last_variable_reference)
-    m.variable_mapping[ref] = MOI.get(m, MOI.NumberOfVariables())
-    push!(m.variable_references, ref)
-    push!(m.variable_primal_solution, NaN)
-    push!(m.variable_dual_solution, NaN)
-    return ref
+    model.last_variable_reference += 1
+    index = VarInd(model.last_variable_reference)
+    model.variable_mapping[index] = MOI.get(model, MOI.NumberOfVariables())
+    push!(model.variable_references, index)
+    push!(model.variable_primal_solution, NaN)
+    push!(model.variable_dual_solution, NaN)
+    return index
 end
 
 #=
     Add multiple variables
 =#
 
-function MOI.addvariables!(m::LinQuadOptimizer, n::Int)
-    previous_vars = MOI.get(m, MOI.NumberOfVariables())
-    add_variables!(m, n)
-    variable_references = VarInd[]
-    sizehint!(variable_references, n)
-    for i in 1:n
+function MOI.addvariables!(model::LinQuadOptimizer, number_to_add::Int)
+    previous_vars = MOI.get(model, MOI.NumberOfVariables())
+    add_variables!(model, number_to_add)
+    variable_indices = VarInd[]
+    sizehint!(variable_indices, number_to_add)
+    for i in 1:number_to_add
         # assumes we add columns linearly
-        m.last_variable_reference += 1
-        ref = VarInd(m.last_variable_reference)
-        push!(variable_references, ref)
+        model.last_variable_reference += 1
+        index = VarInd(model.last_variable_reference)
+        push!(variable_indices, index)
         # m.last_variable_reference might not be the column if we have
         # deleted variables.
-        m.variable_mapping[ref] = previous_vars + i
-        push!(m.variable_references, ref)
-        push!(m.variable_primal_solution, NaN)
-        push!(m.variable_dual_solution, NaN)
+        model.variable_mapping[index] = previous_vars + i
+        push!(model.variable_references, index)
+        push!(model.variable_primal_solution, NaN)
+        push!(model.variable_dual_solution, NaN)
     end
-    return variable_references
+    return variable_indices
 end
 
 #=
     Check if reference is valid
 =#
 
-function MOI.isvalid(m::LinQuadOptimizer, ref::VarInd)
-    if haskey(m.variable_mapping, ref)
-        column = m.variable_mapping[ref]
-        if column > 0 && column <= MOI.get(m, MOI.NumberOfVariables())
+function MOI.isvalid(model::LinQuadOptimizer, index::VarInd)
+    if haskey(model.variable_mapping, index)
+        column = get_column(model, index)
+        if 1 <= column <= MOI.get(model, MOI.NumberOfVariables())
             return true
         end
     end
@@ -118,40 +136,41 @@ end
     Delete a variable
 =#
 
-function MOI.delete!(m::LinQuadOptimizer, ref::VarInd)
-    if !MOI.isvalid(m, ref)
-        throw(MOI.InvalidIndex(ref))
-    end
-    col = m.variable_mapping[ref]
-    delete_variables!(m, col, col)
-
+function MOI.delete!(model::LinQuadOptimizer, index::VarInd)
+    __assert_valid__(model, index)
+    column = get_column(model, index)
+    delete_variables!(model, column, column)
     # delete from problem
-    deleteat!(m.variable_references, col)
-    deleteat!(m.variable_primal_solution, col)
-    deleteat!(m.variable_dual_solution, col)
-    deleteref!(m.variable_mapping, col, ref)
-
+    deleteat!(model.variable_references, column)
+    deleteat!(model.variable_primal_solution, column)
+    deleteat!(model.variable_dual_solution, column)
+    deleteref!(model.variable_mapping, column, index)
     # delete name if not ""
-    if haskey(m.variable_names, ref)
-        name = m.variable_names[ref]
-        delete!(m.variable_names_rev, name)
-        delete!(m.variable_names, ref)
+    if haskey(model.variable_names, index)
+        name = model.variable_names[index]
+        delete!(model.variable_names_rev, name)
+        delete!(model.variable_names, index)
     end
-
-    # delete any bounds
-    # deleting from a dict without the key does nothing
-    deletebyval!(cmap(m).upper_bound, ref)
-    deletebyval!(cmap(m).lower_bound, ref)
-    deletebyval!(cmap(m).fixed_bound, ref)
-    deletebyval!(cmap(m).interval_bound, ref)
-
+    # Delete any bounds (deleting from a dict without the key does nothing).
+    constraint_map = cmap(model)
+    delete_from_dictionary_by_value(constraint_map.upper_bound, index)
+    delete_from_dictionary_by_value(constraint_map.lower_bound, index)
+    delete_from_dictionary_by_value(constraint_map.fixed_bound, index)
+    delete_from_dictionary_by_value(constraint_map.interval_bound, index)
+    return nothing
 end
 
-# temp fix - change storage for bounds
-# TODO(@joaquimg): what did you mean by this?
-function deletebyval!(dict::Dict{S,T}, index::T) where {S,T}
-    for (key, val) in dict
-        if val == index
+"""
+    delete_from_dictionary_by_value(dict::Dict{K, V}, index::V)
+
+Delete the entries of a dictionary where the value of a `key=>value` pair is
+equal to `index`.
+
+This is used to remove bounds when deleting a variable.
+"""
+function delete_from_dictionary_by_value(dict::Dict{K, V}, index::V) where {K, V}
+    for (key, value) in dict
+        if value == index
             delete!(dict, key)
         end
     end
@@ -160,12 +179,16 @@ end
 #=
     MIP starts
 =#
-MOI.supports(model::LinQuadOptimizer, ::MOI.VariablePrimalStart, ::Type{VarInd}) = false
-
-function MOI.set!(m::LinQuadOptimizer, ::MOI.VariablePrimalStart, ref::VarInd, val::Float64)
-    add_mip_starts!(m, [getcol(m, ref)], [val])
+function MOI.supports(::LinQuadOptimizer, ::MOI.VariablePrimalStart, ::Type{VarInd})
+    return false
 end
 
-function MOI.set!(m::LinQuadOptimizer, ::MOI.VariablePrimalStart, refs::Vector{VarInd}, vals::Vector{Float64})
-    add_mip_starts!(m, getcol.(Ref(m), refs), vals)
+function MOI.set!(model::LinQuadOptimizer, ::MOI.VariablePrimalStart,
+                  indices::Vector{VarInd}, values::Vector{Float64})
+    add_mip_starts!(model, get_column.(Ref(model), indices), values)
+end
+
+function MOI.set!(model::LinQuadOptimizer, ::MOI.VariablePrimalStart,
+                  index::VarInd, value::Float64)
+    MOI.set!(model, MOI.VariablePrimalStart(), [index], [value])
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,9 +63,6 @@ const LQOI = LinQuadOptInterface
         @testset "orderedindicestest" begin
             # MOIT.orderedindicestest(solver)
         end
-        @testset "canaddconstrainttest" begin
-            MOIT.canaddconstrainttest(solver, Float64, Complex{Float64})
-        end
         @testset "copytest" begin
             solver2 = LQOI.MockLinQuadOptimizer()
             MOIT.copytest(solver,solver2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,18 +6,12 @@ const MOIT = MathOptInterface.Test
 const LQOI = LinQuadOptInterface
 
 @testset "LinQuadOptInterface" begin
+    solver = LQOI.MockLinQuadOptimizer()
+    # TODO(@joaquim): test with solve=true
+    config = MOIT.TestConfig(solve=false)
+
     @testset "Unit Tests" begin
-        config = MOIT.TestConfig(solve = false)
-        solver = LQOI.MockLinQuadOptimizer()
-        MOIT.basic_constraint_tests(solver, config;
-            exclude = [
-                (MOI.SingleVariable, MOI.EqualTo{Float64}),
-                (MOI.SingleVariable, MOI.Integer),
-                (MOI.SingleVariable, MOI.LessThan{Float64}),
-                (MOI.SingleVariable, MOI.Interval{Float64}),
-                (MOI.SingleVariable, MOI.GreaterThan{Float64})
-            ]
-        )
+        MOIT.basic_constraint_tests(solver, config)
         MOIT.unittest(solver, config, [
             "solve_affine_interval",
             "solve_qp_edge_cases",
@@ -27,45 +21,37 @@ const LQOI = LinQuadOptInterface
     end
 
     @testset "Linear tests" begin
-        linconfig = MOIT.TestConfig(solve = false)
-        solver = LQOI.MockLinQuadOptimizer()
-        MOIT.contlineartest(solver , linconfig)
+        MOIT.contlineartest(solver, config)
     end
 
     @testset "Quadratic tests" begin
-        quadconfig = MOIT.TestConfig(solve=false)
-        solver = LQOI.MockLinQuadOptimizer()
-        MOIT.contquadratictest(solver, quadconfig)
+        MOIT.contquadratictest(solver, config)
     end
 
     @testset "Linear Conic tests" begin
-        linconfig = MOIT.TestConfig(solve=false)
-        solver = LQOI.MockLinQuadOptimizer()
-        MOIT.lintest(solver, linconfig)
+        MOIT.lintest(solver, config)
     end
 
     @testset "Integer Linear tests" begin
-        intconfig = MOIT.TestConfig(solve=false)
-        solver = LQOI.MockLinQuadOptimizer()
-        MOIT.intlineartest(solver, intconfig, ["int2"])
+        MOIT.intlineartest(solver, config, ["int2"])
     end
 
     @testset "ModelLike tests" begin
-        intconfig = MOIT.TestConfig()
-        solver = LQOI.MockLinQuadOptimizer()
-        MOIT.nametest(solver)
+        @testset "nametest" begin
+            MOIT.nametest(LQOI.MockLinQuadOptimizer())
+        end
         @testset "validtest" begin
-            MOIT.validtest(solver)
+            MOIT.validtest(LQOI.MockLinQuadOptimizer())
         end
         @testset "emptytest" begin
-            MOIT.emptytest(solver)
+            MOIT.emptytest(LQOI.MockLinQuadOptimizer())
         end
         @testset "orderedindicestest" begin
-            # MOIT.orderedindicestest(solver)
+            MOIT.orderedindicestest(LQOI.MockLinQuadOptimizer())
         end
         @testset "copytest" begin
-            solver2 = LQOI.MockLinQuadOptimizer()
-            MOIT.copytest(solver,solver2)
+            MOIT.copytest(LQOI.MockLinQuadOptimizer(),
+                          LQOI.MockLinQuadOptimizer())
         end
     end
 end


### PR DESCRIPTION
This PR begins to implement https://github.com/JuliaOpt/MathOptInterface.jl/pull/436

### Test status

<s>Tests are currently failing but at least it compiles.</s>
Can't test v0.7 because how do I checkout MOI master?

### Thoughts so far:
- [x] Should there be a general exception? What should I throw when someone goes:
```julia
MOI.get(m, MOI.VariableIndex, "name_doesnt_exist")
```
- [x] Who is responsible for throwing errors? MOI? LQOI? Solvers?
- [x] I almost always want to provide a string with additional information. The cachingoptimizer can look at the type, but users will want a string.
- [x] LQOI needs a clean

### TODO

- [x] Fix travis (currently checking out MOI master)
- [ ] Change MOI require bound

cc @blegat 