### PR TITLE
return nothing from optimize

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -63,6 +63,7 @@ function MOI.optimize!(model::LinQuadOptimizer)
         model.constraint_dual_solution *= -1
         model.variable_dual_solution *= -1
     end
+    return
 end
 
 


### PR DESCRIPTION
Previously `optimize!` was sometimes returning `model.variable_dual_solution`.