### PR TITLE
Replace check for conflicting constraints with an O(1) cache

### DIFF
--- a/src/LinQuadOptInterface.jl
+++ b/src/LinQuadOptInterface.jl
@@ -199,6 +199,8 @@ end
 # Abstract + macro
 abstract type LinQuadOptimizer <: MOI.AbstractOptimizer end
 
+@enum(VariableType, Continuous, Binary, Integer, Semiinteger, Semicontinuous)
+
 macro LinQuadOptimizerBase(inner_model_type=Any)
     esc(quote
     inner::$inner_model_type
@@ -214,6 +216,7 @@ macro LinQuadOptimizerBase(inner_model_type=Any)
     variable_names::Dict{MOI.VariableIndex, String}
     variable_names_rev::Dict{String, MOI.VariableIndex}
     variable_references::Vector{MOI.VariableIndex}
+    variable_type::Dict{MOI.VariableIndex, LinQuadOptInterface.VariableType}
 
     variable_primal_solution::Vector{Float64}
     variable_dual_solution::Vector{Float64}
@@ -256,6 +259,7 @@ function MOI.is_empty(m::LinQuadOptimizer)
     ret = ret && isempty(m.variable_names)
     ret = ret && isempty(m.variable_names_rev)
     ret = ret && isempty(m.variable_references)
+    ret = ret && isempty(m.variable_type)
     ret = ret && isempty(m.variable_primal_solution)
     ret = ret && isempty(m.variable_dual_solution)
     ret = ret && m.last_constraint_reference == 0
@@ -291,7 +295,7 @@ function MOI.empty!(m::M, env = nothing) where M<:LinQuadOptimizer
     m.variable_names = Dict{MathOptInterface.VariableIndex, String}()
     m.variable_names_rev = Dict{String, MathOptInterface.VariableIndex}()
     m.variable_references = MathOptInterface.VariableIndex[]
-
+    m.variable_type = Dict{MathOptInterface.VariableIndex, VariableType}()
     m.variable_primal_solution = Float64[]
     m.variable_dual_solution = Float64[]
 

--- a/src/constraints/singlevariable.jl
+++ b/src/constraints/singlevariable.jl
@@ -66,52 +66,12 @@ function has_value(dict::Dict{K, V}, value::V) where {K, V}
     return value in values(dict)
 end
 
-"""
-    __check_for_conflicting__(model::LinQuadOptimizer, variable::SinVar, set,
-                              conflicting_type::Type{<:AbstractSet})
-
-Throw an error if `variable` is already constrained to be in a set of type
-`conflicting_type`.
-"""
-function __check_for_conflicting__(model::LinQuadOptimizer, variable::SinVar, set,
-                                   conflict_type::Type{<:MOI.AbstractSet})
-    if has_value(constrdict(model, SVCI{conflict_type}(0)), variable.variable)
-        error("Cannot add constraint $(variable)-in-$(set) as it is already " *
-              "constrained by a set of type $(conflict_type).")
-    end
-end
-
-function __check_for_conflicting__(model::LinQuadOptimizer, variable::SinVar, set,
-                                   conflict_type::Type{MOI.ZeroOne})
-    for (index, lower, upper) in values(constrdict(model, SVCI{conflict_type}(0)))
-        if index == variable.variable
-            error("Cannot add constraint $(variable)-in-$(set) as it is already " *
-                  "constrained by a set of type $(conflict_type).")
-        end
-    end
-end
-
-
-"""
-    __check_for_conflicting__(model::LinQuadOptimizer, variable::SinVar, set,
-                              conflicting_types::AbstractSet...)
-
-Throw an error if `variable` is constrained to be in a set whose type is one of
-`conflicting_types`.
-"""
-function __check_for_conflicting__(model::LinQuadOptimizer, variable::SinVar, set,
-                                   conflicting_types...)
-    for conflict_type in conflicting_types
-        __check_for_conflicting__(model, variable, set, conflict_type)
-    end
-end
-
 function MOI.add_constraint(model::LinQuadOptimizer, variable::SinVar, set::S) where S <: LinSets
     __assert_supported_constraint__(model, SinVar, S)
-    # Since the following "variable type" sets also define bounds (implicitly or explicitly),
-    # they may conflict with other bound constraints.
-    __check_for_conflicting__(model, variable, set,
-        S, MOI.Semicontinuous{Float64}, MOI.Semiinteger{Float64}, MOI.ZeroOne)
+    variable_type = model.variable_type[variable.variable]
+    if !(variable_type == Continuous || variable_type == Integer)
+        error("Cannot set bounds because variable is of type: $(variable_type).")
+    end
     set_variable_bound(model, variable, set)
     model.last_constraint_reference += 1
     index = SVCI{S}(model.last_constraint_reference)
@@ -124,9 +84,11 @@ function MOI.delete(model::LinQuadOptimizer, index::SVCI{S}) where S <: LinSets
     __assert_valid__(model, index)
     delete_constraint_name(model, index)
     dict = constrdict(model, index)
-    variable_index = dict[index]
-    set_variable_bound(model, SinVar(variable_index), IV(-Inf, Inf))
+    variable = dict[index]
+    model.variable_type[variable] = Continuous
+    set_variable_bound(model, SinVar(variable), IV(-Inf, Inf))
     delete!(dict, index)
+    return
 end
 
 # constraint set
@@ -174,8 +136,11 @@ user does.
 =#
 function MOI.add_constraint(model::LinQuadOptimizer, variable::SinVar, set::MOI.ZeroOne)
     __assert_supported_constraint__(model, SinVar, MOI.ZeroOne)
-    __check_for_conflicting__(model, variable, set, MOI.ZeroOne, MOI.Integer,
-        MOI.Semicontinuous{Float64}, MOI.Semiinteger{Float64})
+    variable_type = model.variable_type[variable.variable]
+    if variable_type != Continuous
+        error("Cannot make variable binary because it is $(variable_type).")
+    end
+    model.variable_type[variable.variable] = Binary
     model.last_constraint_reference += 1
     index = SVCI{MOI.ZeroOne}(model.last_constraint_reference)
     column = get_column(model, variable)
@@ -198,6 +163,7 @@ function MOI.delete(model::LinQuadOptimizer, index::SVCI{MOI.ZeroOne})
     delete_constraint_name(model, index)
     dict = constrdict(model, index)
     (variable, lower, upper) = dict[index]
+    model.variable_type[variable] = Continuous
     column = get_column(model, variable)
     change_variable_types!(
         model, [column], [backend_type(model, Val{:Continuous}())])
@@ -227,8 +193,11 @@ end
 
 function MOI.add_constraint(model::LinQuadOptimizer, variable::SinVar, set::MOI.Integer)
     __assert_supported_constraint__(model, SinVar, MOI.Integer)
-    __check_for_conflicting__(model, variable, set, MOI.ZeroOne,
-        MOI.Semicontinuous{Float64}, MOI.Semiinteger{Float64})
+    variable_type = model.variable_type[variable.variable]
+    if variable_type != Continuous
+        error("Cannot make variable integer because it is $(variable_type).")
+    end
+    model.variable_type[variable.variable] = Integer
     change_variable_types!(model, [get_column(model, variable)],
                            [backend_type(model, set)])
     model.last_constraint_reference += 1
@@ -244,6 +213,7 @@ function MOI.delete(model::LinQuadOptimizer, index::SVCI{MOI.Integer})
     delete_constraint_name(model, index)
     dict = constrdict(model, index)
     variable = dict[index]
+    model.variable_type[variable] = Continuous
     change_variable_types!(model, [get_column(model, variable)],
                            [backend_type(model, Val{:Continuous}())])
     delete!(dict, index)
@@ -265,14 +235,15 @@ end
     Semicontinuous / Semiinteger constraints
 =#
 const SEMI_TYPES = Union{MOI.Semicontinuous{Float64}, MOI.Semiinteger{Float64}}
+variable_type_(::Type{<:MOI.Semicontinuous}) = Semicontinuous
+variable_type_(::Type{<:MOI.Semiinteger}) = Semiinteger
 function MOI.add_constraint(model::LinQuadOptimizer, variable::SinVar, set::S) where S <: SEMI_TYPES
     __assert_supported_constraint__(model, SinVar, S)
-    __check_for_conflicting__(model, variable, set, S, MOI.ZeroOne, MOI.Integer)
-    if S == MOI.Semicontinuous{Float64}
-        __check_for_conflicting__(model, variable, set, MOI.Semiinteger{Float64})
-    else
-        __check_for_conflicting__(model, variable, set, MOI.Semicontinuous{Float64})
+    variable_type = model.variable_type[variable.variable]
+    if variable_type != Continuous
+        error("Cannot make variable $(S) because it is $(variable_type).")
     end
+    model.variable_type[variable.variable] = variable_type_(S)
     column = get_column(model, variable)
     change_variable_types!(model, [column], [backend_type(model, set)])
     change_variable_bounds!(model,
@@ -293,7 +264,9 @@ function MOI.delete(model::LinQuadOptimizer, index::SVCI{<:SEMI_TYPES})
     __assert_valid__(model, index)
     delete_constraint_name(model, index)
     dict = constrdict(model, index)
-    column = get_column(model, dict[index])
+    variable = dict[index]
+    column = get_column(model, variable)
+    model.variable_type[variable] = Continuous
     change_variable_types!(model, [column], [backend_type(model, Val{:Continuous}())])
     change_variable_bounds!(model,
         [column, column],

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -92,6 +92,7 @@ function MOI.add_variable(model::LinQuadOptimizer)
     push!(model.variable_references, index)
     push!(model.variable_primal_solution, NaN)
     push!(model.variable_dual_solution, NaN)
+    model.variable_type[index] = Continuous
     return index
 end
 
@@ -115,6 +116,7 @@ function MOI.add_variables(model::LinQuadOptimizer, number_to_add::Int)
         push!(model.variable_references, index)
         push!(model.variable_primal_solution, NaN)
         push!(model.variable_dual_solution, NaN)
+        model.variable_type[index] = Continuous
     end
     return variable_indices
 end
@@ -143,6 +145,7 @@ function MOI.delete(model::LinQuadOptimizer, index::VarInd)
     delete_variables!(model, column, column)
     # delete from problem
     deleteat!(model.variable_references, column)
+    delete!(model.variable_type, index)
     deleteat!(model.variable_primal_solution, column)
     deleteat!(model.variable_dual_solution, column)
     deleteref!(model.variable_mapping, column, index)


### PR DESCRIPTION
Closes https://github.com/JuliaOpt/LinQuadOptInterface.jl/issues/51
```julia
using Gurobi, JuMP, BenchmarkTools
function run_moi_direct(n)
  m = JuMP.direct_model(Gurobi.Optimizer(LogToConsole=false))
  @variable m x[i=1:n] <= i 
  # JuMP.optimize!(m)
end
@btime run_moi_direct(10^4)
```

Before this PR: 1.05 seconds.
With this PR: 0.48 seconds