### PR TITLE
WIP: Large re-write to simplify SingleVariable constraints

### DIFF
--- a/src/LinQuadOptInterface.jl
+++ b/src/LinQuadOptInterface.jl
@@ -237,7 +237,7 @@ macro LinQuadOptimizerBase(inner_model_type=Any)
     obj_sense::MOI.OptimizationSense
 
     last_variable_reference::UInt64
-    variable_mapping::Dict{MOI.VariableIndex, LinQuadOptInterface.VariableCache}
+    variable_cache::Dict{MOI.VariableIndex, LinQuadOptInterface.VariableCache}
     variable_names_rev::Dict{String, Set{MOI.VariableIndex}}
     variable_references::Vector{MOI.VariableIndex}
     variable_primal_solution::Vector{Float64}
@@ -276,7 +276,7 @@ function MOI.is_empty(m::LinQuadOptimizer)
     ret = ret && isa(m.single_obj_var, Nothing)
     ret = ret && m.obj_sense == MOI.MIN_SENSE
     ret = ret && m.last_variable_reference == 0
-    ret = ret && isempty(m.variable_mapping)
+    ret = ret && isempty(m.variable_cache)
     ret = ret && isempty(m.variable_names_rev)
     ret = ret && isempty(m.variable_references)
     ret = ret && isempty(m.variable_primal_solution)
@@ -309,7 +309,7 @@ function MOI.empty!(m::M, env = nothing) where M<:LinQuadOptimizer
     m.obj_sense = MOI.MIN_SENSE
 
     m.last_variable_reference = 0
-    m.variable_mapping = Dict{MathOptInterface.VariableIndex, VariableCache}()
+    m.variable_cache = Dict{MathOptInterface.VariableIndex, VariableCache}()
     m.variable_names_rev = Dict{String, Set{MathOptInterface.VariableIndex}}()
     m.variable_references = MathOptInterface.VariableIndex[]
     m.variable_primal_solution = Float64[]

--- a/src/LinQuadOptInterface.jl
+++ b/src/LinQuadOptInterface.jl
@@ -212,6 +212,9 @@ mutable struct VariableCache
     variable_type::VariableType
     bound_type::VariableBoundType
     name::String
+    # These are used when setting ZeroOne constraints
+    lower_old::Float64
+    upper_old::Float64
     function VariableCache(;
         column,
         lower = -Inf,
@@ -219,7 +222,7 @@ mutable struct VariableCache
         variable_type = CONTINUOUS,
         bound_type = FREE,
         name = "")
-        return new(column, lower, upper, variable_type, bound_type, name)
+        return new(column, lower, upper, variable_type, bound_type, name, NaN, NaN)
     end
 end
 

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -30,13 +30,13 @@ binary, integer, special ordered sets, semicontinuous, or semi-integer
 variables).
 """
 function has_integer(model::LinQuadOptimizer)
+    for (variable, cache) in model.variable_mapping
+        if cache.variable_type != CONTINUOUS
+            return true
+        end
+    end
     constraint_map = cmap(model)
-    return length(constraint_map.integer) > 0 ||
-        length(constraint_map.binary) > 0 ||
-        length(constraint_map.sos1) > 0 ||
-        length(constraint_map.sos2) > 0 ||
-        length(constraint_map.semicontinuous) > 0 ||
-        length(constraint_map.semiinteger) > 0
+    return length(constraint_map.sos1) > 0 || length(constraint_map.sos2) > 0
 end
 
 #=

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -30,7 +30,7 @@ binary, integer, special ordered sets, semicontinuous, or semi-integer
 variables).
 """
 function has_integer(model::LinQuadOptimizer)
-    for (variable, cache) in model.variable_mapping
+    for (variable, cache) in model.variable_cache
         if cache.variable_type != CONTINUOUS
             return true
         end

--- a/src/constraints/scalaraffine.jl
+++ b/src/constraints/scalaraffine.jl
@@ -209,7 +209,7 @@ of this function.
 """
 function _replace_with_matching_sparsity!(model::LinQuadOptimizer, previous::Linear, replacement::Linear, row)
     rows = fill(row, length(replacement.terms))
-    cols = [model.variable_mapping[t.variable_index] for t in replacement.terms]
+    cols = [get_column(model, t.variable_index) for t in replacement.terms]
     coefs = MOI.coefficient.(replacement.terms)
     change_matrix_coefficients!(model, rows, cols, coefs)
 end
@@ -234,13 +234,13 @@ the sparsity patterns match, the zeroing-out step can be skipped.
 function _replace_with_different_sparsity!(model::LinQuadOptimizer, previous::Linear, replacement::Linear, row)
     # First, zero out the old constraint function terms
     rows = fill(row, length(previous.terms))
-    cols = [model.variable_mapping[t.variable_index] for t in previous.terms]
+    cols = [get_column(model, t.variable_index) for t in previous.terms]
     coefs = fill(0.0, length(previous.terms))
     change_matrix_coefficients!(model, rows, cols, coefs)
 
     # Next, set the new constraint function terms
     rows = fill(row, length(replacement.terms))
-    cols = [model.variable_mapping[t.variable_index] for t in replacement.terms]
+    cols = [get_column(model, t.variable_index) for t in replacement.terms]
     coefs = MOI.coefficient.(replacement.terms)
     change_matrix_coefficients!(model, rows, cols, coefs)
 end

--- a/src/constraints/singlevariable.jl
+++ b/src/constraints/singlevariable.jl
@@ -65,7 +65,7 @@ function constraint_index(variable::MOI.SingleVariable, set::S) where {S}
 end
 
 function variable_cache(model::LinQuadOptimizer, index::MOI.VariableIndex)
-    return model.variable_mapping[index]
+    return model.variable_cache[index]
 end
 
 function variable_cache(model::LinQuadOptimizer, index::SVCI)
@@ -88,7 +88,7 @@ end
 # TODO(odow): we could cache this. It seems very inefficient.
 function MOI.get(model::LinQuadOptimizer, ::MOI.NumberOfConstraints{MOI.SingleVariable, S}) where {S}
     num = 0
-    for (index, cache) in model.variable_mapping
+    for (index, cache) in model.variable_cache
         if has_constraint_filter(cache, S)
             num += 1
         end

--- a/src/constraints/singlevariable.jl
+++ b/src/constraints/singlevariable.jl
@@ -1,25 +1,280 @@
-#=
-    Variable bounds
-        SingleVariable -in- LessThan
-        SingleVariable -in- GreaterThan
-        SingleVariable -in- EqualTo
-        SingleVariable -in- Interval
+# Notes to begin.
+#
+# For all SingleVariable-in-X constraints, we use the same index as the variable
+# index. This implies that we cannot add two constraints of the same type. In
+# addition, some combinations of constraints are forbidden. Unfortunately, this
+# means that SingleVariable-in-Sets are not returned ordered  by creation with
+# ListOfConstraintIndices, they are ordered by variable creation.
 
-        SingleVariable -in- ZeroOne
-        SingleVariable -in- Integer
-        SingleVariable -in- Semiinteger
-        SingleVariable -in- Semicontinuous
-=#
-constrdict(model::LinQuadOptimizer, ::SVCI{LE}) = cmap(model).upper_bound
-constrdict(model::LinQuadOptimizer, ::SVCI{GE}) = cmap(model).lower_bound
-constrdict(model::LinQuadOptimizer, ::SVCI{EQ}) = cmap(model).fixed_bound
-constrdict(model::LinQuadOptimizer, ::SVCI{IV}) = cmap(model).interval_bound
+function throw_conflicting_variable_type(set, variable_type)
+    error("Cannot add $(set) constraint because variable is $(variable_type).")
+end
 
-constrdict(model::LinQuadOptimizer, ::SVCI{MOI.ZeroOne}) = cmap(model).binary
-constrdict(model::LinQuadOptimizer, ::SVCI{MOI.Integer}) = cmap(model).integer
+function throw_conflicting_upper_bound(set)
+    error("Cannot add $(set) constraint because an upper bound already exists.")
+end
 
-constrdict(model::LinQuadOptimizer, ::SVCI{MOI.Semicontinuous{Float64}}) = cmap(model).semicontinuous
-constrdict(model::LinQuadOptimizer, ::SVCI{MOI.Semiinteger{Float64}}) = cmap(model).semiinteger
+function throw_conflicting_lower_bound(set)
+    error("Cannot add $(set) constraint because a lower bound already exists.")
+end
+
+"""
+    has_constraint_filter(cache::VariableCache, set::S) where {S}
+
+Return `true` if the variable associated with the variable cache `cache` has a
+constraint of type `MOI.ConstraintIndex{MOI.SingleVariable, S}`.
+"""
+has_constraint_filter(::VariableCache, arg) = false
+
+"""
+    variable_index(c_index::SVCI)
+
+Convert a `ConstraintIndex{SingleVariable, S}` to a `VariableIndex`.
+"""
+function variable_index(c_index::SVCI)
+    return MOI.VariableIndex(c_index.value)
+end
+
+variable_index(index::MOI.SingleVariable) = index.variable
+
+"""
+    single_variable(c_index::SVCI)
+
+Convert a `ConstraintIndex{SingleVariable, S}` to a `SingleVariable`.
+"""
+function single_variable(c_index::SVCI)
+    return MOI.SingleVariable(variable_index(c_index))
+end
+
+"""
+    constraint_index(variable::VariableIndex, ::S)
+
+Convert a `VariableIndex` to a `ConstraintIndex{SingleVariable, S}`.
+"""
+function constraint_index(variable::MOI.VariableIndex, ::S) where {S}
+    return MOI.ConstraintIndex{MOI.SingleVariable, S}(variable.value)
+end
+
+"""
+    constraint_index(variable::SingleVariable, ::S)
+
+Convert a `SingleVariable` to a `ConstraintIndex{SingleVariable, S}`.
+"""
+function constraint_index(variable::MOI.SingleVariable, set::S) where {S}
+    return constraint_index(variable.variable, set)
+end
+
+function variable_cache(model::LinQuadOptimizer, index::MOI.VariableIndex)
+    return model.variable_mapping[index]
+end
+
+function variable_cache(model::LinQuadOptimizer, index::SVCI)
+    return variable_cache(model, variable_index(index))
+end
+
+function variable_cache(model::LinQuadOptimizer, index::MOI.SingleVariable)
+    return variable_cache(model, variable_index(index))
+end
+
+function MOI.is_valid(model::LinQuadOptimizer, index::SVCI{S}) where {S}
+    cache = variable_cache(model, index)
+    return has_constraint_filter(cache, S)
+end
+
+function MOI.get(::LinQuadOptimizer, ::MOI.ConstraintFunction, index::SVCI)
+    return single_variable(index)
+end
+
+# TODO(odow): we could cache this. It seems very inefficient.
+function MOI.get(model::LinQuadOptimizer, ::MOI.NumberOfConstraints{MOI.SingleVariable, S}) where {S}
+    num = 0
+    for (index, cache) in model.variable_mapping
+        if has_constraint_filter(cache, S)
+            num += 1
+        end
+    end
+    return num
+end
+
+# Get the list of constraint indices. We order them by variable creation time,
+# i.e., the order of variables in model.variable_references, which should be
+# their column ordering.
+function MOI.get(model::LinQuadOptimizer, ::MOI.ListOfConstraintIndices{MOI.SingleVariable, S}) where {S}
+    indices = MOI.ConstraintIndex{MOI.SingleVariable, S}[]
+    for variable in model.variable_references
+        cache = variable_cache(model, variable)
+        if has_constraint_filter(cache, S)
+            push!(indices, MOI.ConstraintIndex{MOI.SingleVariable, S}(variable.value))
+        end
+    end
+    return indices
+end
+
+###
+### SingleVariable in LessThan, GreaterThan, Interval, EqualTo
+###
+
+function set_cache(cache::VariableCache, set::MOI.LessThan)
+    cache.upper = set.upper
+    cache.bound_type = cache.bound_type == ONLY_GREATER_THAN ? LESS_AND_GREATER_THAN : ONLY_LESS_THAN
+    return
+end
+
+function unset_cache(cache::VariableCache, ::Type{<:MOI.LessThan})
+    cache.upper = Inf
+    cache.bound_type = cache.bound_type == LESS_AND_GREATER_THAN ? ONLY_GREATER_THAN : FREE
+    return
+end
+
+function set_cache(cache::VariableCache, set::MOI.GreaterThan)
+    cache.lower = set.lower
+    cache.bound_type = cache.bound_type == ONLY_LESS_THAN ? LESS_AND_GREATER_THAN : ONLY_GREATER_THAN
+    return
+end
+
+function unset_cache(cache::VariableCache, ::Type{<:MOI.GreaterThan})
+    cache.lower = -Inf
+    cache.bound_type = cache.bound_type == LESS_AND_GREATER_THAN ? ONLY_LESS_THAN : FREE
+    return
+end
+
+function set_cache(cache::VariableCache, set::MOI.Interval)
+    cache.lower = set.lower
+    cache.upper = set.upper
+    cache.bound_type = INTERVAL
+    return
+end
+
+function set_cache(cache::VariableCache, set::MOI.EqualTo)
+    cache.lower = set.value
+    cache.upper = set.value
+    cache.bound_type = EQUAL_TO
+    return
+end
+
+function unset_cache(cache::VariableCache, ::Type{<:Union{MOI.Interval, MOI.EqualTo}})
+    cache.lower = -Inf
+    cache.upper = Inf
+    cache.bound_type = FREE
+    return
+end
+
+function MOI.add_constraint(model::LinQuadOptimizer, variable::SinVar, set::S) where S <: LinSets
+    __assert_supported_constraint__(model, SinVar, S)
+    cache = variable_cache(model, variable)
+    check_conflicting_constraint(cache, set)
+    set_variable_bound(model, variable, set)
+    set_cache(cache, set)
+    return constraint_index(variable, set)
+end
+
+function MOI.add_constraints(model::LinQuadOptimizer, variables::Vector{SinVar},
+                             sets::Vector{S}) where S <: LinSets
+    __assert_supported_constraint__(model, SinVar, S)
+    for (variable, set) in zip(variables, sets)
+        check_conflicting_constraint(variable_cache(model, variable), set)
+    end
+    set_variable_bounds(model, variables, sets)
+    indices = SVCI{S}[]
+    for (variable, set) in zip(variables, sets)
+        cache = variable_cache(model, variable)
+        set_cache(cache, set)
+        push!(indices, constraint_index(variable, set))
+    end
+    return indices
+end
+
+function MOI.delete(model::LinQuadOptimizer, index::SVCI{S}) where {S <: LinSets}
+    __assert_valid__(model, index)
+    cache = variable_cache(model, index)
+    unset_cache(cache, S)
+    set_variable_bound(model, single_variable(index), IV(cache.lower, cache.upper))
+    return
+end
+
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintSet, index::SVCI{LE})
+    cache = variable_cache(model, index)
+    return MOI.LessThan{Float64}(cache.upper)
+end
+
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintSet, index::SVCI{GE})
+    cache = variable_cache(model, index)
+    return MOI.GreaterThan{Float64}(cache.lower)
+end
+
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintSet, index::SVCI{EQ})
+    cache = variable_cache(model, index)
+    return MOI.EqualTo{Float64}(cache.lower)
+end
+
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintSet, index::SVCI{IV})
+    cache = variable_cache(model, index)
+    return MOI.Interval{Float64}(cache.lower, cache.upper)
+end
+
+MOI.supports(::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{SVCI{<:LinSets}}) = true
+function MOI.set(model::LinQuadOptimizer, ::MOI.ConstraintSet, index::SVCI{S}, new_set::S) where S <: LinSets
+    cache = variable_cache(model, index)
+    set_variable_bound(model, single_variable(index), new_set)
+    set_cache(cache, new_set)
+    return
+end
+
+function has_constraint_filter(cache::VariableCache, ::Type{<:MOI.LessThan})
+    return cache.bound_type == ONLY_LESS_THAN || cache.bound_type == LESS_AND_GREATER_THAN
+end
+
+function has_constraint_filter(cache::VariableCache, ::Type{<:MOI.GreaterThan})
+    return cache.bound_type == ONLY_GREATER_THAN || cache.bound_type == LESS_AND_GREATER_THAN
+end
+
+function has_constraint_filter(cache::VariableCache, ::Type{<:MOI.EqualTo})
+    return cache.bound_type == EQUAL_TO
+end
+
+function has_constraint_filter(cache::VariableCache, ::Type{<:MOI.Interval})
+    return cache.bound_type == INTERVAL
+end
+
+function check_conflicting_constraint(cache::VariableCache, ::MOI.LessThan)
+    if cache.variable_type == SEMI_INTEGER || cache.variable_type == SEMI_CONTINUOUS
+        throw_conflicting_variable_type(MOI.LessThan, cache.variable_type)
+    elseif cache.upper != Inf
+        throw_conflicting_upper_bound(MOI.LessThan)
+    end
+    return
+end
+
+function check_conflicting_constraint(cache::VariableCache, ::MOI.GreaterThan)
+    if cache.variable_type == SEMI_INTEGER || cache.variable_type == SEMI_CONTINUOUS
+        throw_conflicting_variable_type(MOI.GreaterThan, cache.variable_type)
+    elseif cache.lower != -Inf
+        throw_conflicting_lower_bound(MOI.GreaterThan)
+    end
+    return
+end
+
+function check_conflicting_constraint(cache::VariableCache, ::MOI.Interval)
+    if cache.variable_type == SEMI_INTEGER || cache.variable_type == SEMI_CONTINUOUS || cache.variable_type == BINARY
+        throw_conflicting_variable_type(MOI.Interval, cache.variable_type)
+    elseif cache.lower != -Inf
+        throw_conflicting_lower_bound(MOI.Interval)
+    elseif cache.upper != Inf
+        throw_conflicting_upper_bound(MOI.Interval)
+    end
+    return
+end
+
+function check_conflicting_constraint(cache::VariableCache, ::MOI.EqualTo)
+    if cache.variable_type == SEMI_INTEGER || cache.variable_type == SEMI_CONTINUOUS
+        throw_conflicting_variable_type(MOI.EqualTo, cache.variable_type)
+    elseif cache.lower != -Inf
+        throw_conflicting_lower_bound(MOI.EqualTo)
+    elseif cache.upper != Inf
+        throw_conflicting_upper_bound(MOI.EqualTo)
+    end
+    return
+end
 
 """
     change_both_variable_bounds!(model::LinQuadOptimizer, columns::Vector{Int},
@@ -96,144 +351,33 @@ function set_variable_bounds(
         [set.lower for set in sets], [set.upper for set in sets])
 end
 
-"""
-    has_value(dict::Dict{K, V}, value::V) where {K, V}
+###
+### SingleVariable in ZeroOne
+###
+### Conflicts with Integer, Semicontinuous, and Semiinteger constraints.
+###
+### Note: some solvers may have unusual behaviour with variable bounds and
+### binary variables. LQOI will happily change the variable type to Binary if
+### there are bounds present; it's up to the solver to decide whether to respect
+### the existing bounds, and whether to restore them when this constraint is
+### deleted.
 
-Return true if `dict` has a `key=>value` pair with `value`.
-"""
-function has_value(dict::Dict{K, V}, value::V) where {K, V}
-    return value in values(dict)
-end
-
-function MOI.add_constraint(model::LinQuadOptimizer, variable::SinVar, set::S) where S <: LinSets
-    __assert_supported_constraint__(model, SinVar, S)
-    variable_type = model.variable_type[variable.variable]
-    if !(variable_type == CONTINUOUS || variable_type == INTEGER)
-        error("Cannot set bounds because variable is of type: $(variable_type).")
-    end
-    set_variable_bound(model, variable, set)
-    model.last_constraint_reference += 1
-    index = SVCI{S}(model.last_constraint_reference)
-    dict = constrdict(model, index)
-    dict[index] = variable.variable
-    return index
-end
-
-function MOI.add_constraints(model::LinQuadOptimizer, variables::Vector{SinVar},
-                             sets::Vector{S}) where S <: LinSets
-    __assert_supported_constraint__(model, SinVar, S)
-    for variable in variables
-        variable_type = model.variable_type[variable.variable]
-        if !(variable_type == CONTINUOUS || variable_type == INTEGER)
-            error("Cannot set bounds because variable is of type: $(variable_type).")
-        end
-    end
-    set_variable_bounds(model, variables, sets)
-    indices = SVCI{S}[]
-    for variable in variables
-        model.last_constraint_reference += 1
-        index = SVCI{S}(model.last_constraint_reference)
-        dict = constrdict(model, index)
-        dict[index] = variable.variable
-        push!(indices, index)
-    end
-    return indices
-end
-
-function MOI.delete(model::LinQuadOptimizer, index::SVCI{S}) where S <: LinSets
-    __assert_valid__(model, index)
-    delete_constraint_name(model, index)
-    dict = constrdict(model, index)
-    variable = dict[index]
-    model.variable_type[variable] = CONTINUOUS
-    set_variable_bound(model, SinVar(variable), IV(-Inf, Inf))
-    delete!(dict, index)
-    return
-end
-
-# constraint set
-function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintSet, index::SVCI{LE})
-    MOI.LessThan{Float64}(
-        get_variable_upperbound(model, get_column(model, model[index]))
-    )
-end
-function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintSet, index::SVCI{GE})
-    MOI.GreaterThan{Float64}(
-        get_variable_lowerbound(model, get_column(model, model[index]))
-    )
-end
-function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintSet, index::SVCI{EQ})
-    MOI.EqualTo{Float64}(
-        get_variable_lowerbound(model, get_column(model, model[index]))
-    )
-end
-function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintSet, index::SVCI{IV})
-    column = get_column(model, model[index])
-    return MOI.Interval{Float64}(get_variable_lowerbound(model, column),
-                                 get_variable_upperbound(model, column))
-end
-
-# constraint function
-function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintFunction, index::SVCI{<: LinSets})
-    return SinVar(model[index])
-end
-
-# modify
-MOI.supports(::LinQuadOptimizer, ::MOI.ConstraintSet, ::Type{SVCI{S}}) where S<:LinSets = true
-function MOI.set(model::LinQuadOptimizer, ::MOI.ConstraintSet, index::SVCI{S}, newset::S) where S <: LinSets
-    set_variable_bound(model, SinVar(model[index]), newset)
-end
-
-#=
-    Binary constraints
-
-For some reason CPLEX doesn't respect bounds on a binary variable, so we should
-store the previous bounds so that if we delete the binary constraint we can
-revert to the old bounds.
-
-Xpress is worse, once binary, the bounds are changed independently of what the
-user does.
-=#
 function MOI.add_constraint(model::LinQuadOptimizer, variable::SinVar, set::MOI.ZeroOne)
     __assert_supported_constraint__(model, SinVar, MOI.ZeroOne)
-    variable_type = model.variable_type[variable.variable]
-    if variable_type != CONTINUOUS
-        error("Cannot make variable binary because it is $(variable_type).")
-    end
-    model.variable_type[variable.variable] = BINARY
-    model.last_constraint_reference += 1
-    index = SVCI{MOI.ZeroOne}(model.last_constraint_reference)
-    column = get_column(model, variable)
-    dict = constrdict(model, index)
-    dict[index] = (variable.variable, get_variable_lowerbound(model, column),
-                   get_variable_upperbound(model, column))
-    change_variable_types!(model, [column], [backend_type(model, set)])
-    change_variable_bounds!(model,
-        [column, column],
-        [0.0, 1.0],
-        [backend_type(model, Val{:Lowerbound}()),
-         backend_type(model, Val{:Upperbound}())]
-    )
+    cache = variable_cache(model, variable)
+    check_conflicting_constraint(cache, set)
+    cache.variable_type = BINARY
+    change_variable_types!(model, [cache.column], [backend_type(model, set)])
     make_problem_type_integer(model)
-    return index
+    return constraint_index(variable, set)
 end
 
 function MOI.delete(model::LinQuadOptimizer, index::SVCI{MOI.ZeroOne})
     __assert_valid__(model, index)
-    delete_constraint_name(model, index)
-    dict = constrdict(model, index)
-    (variable, lower, upper) = dict[index]
-    model.variable_type[variable] = CONTINUOUS
-    column = get_column(model, variable)
+    cache = variable_cache(model, index)
+    cache.variable_type = CONTINUOUS
     change_variable_types!(
-        model, [column], [backend_type(model, Val{:Continuous}())])
-    change_variable_bounds!(model,
-       [column, column],
-       [lower, upper],
-       [backend_type(model, Val{:Lowerbound}()),
-        backend_type(model, Val{:Upperbound}())]
-    )
-    delete!(dict, index)
+        model, [cache.column], [backend_type(model, Val{:Continuous}())])
     if !has_integer(model)
         make_problem_type_continuous(model)
     end
@@ -243,40 +387,38 @@ function MOI.get(::LinQuadOptimizer, ::MOI.ConstraintSet, ::SVCI{MOI.ZeroOne})
     return MOI.ZeroOne()
 end
 
-function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintFunction, index::SVCI{MOI.ZeroOne})
-    return SinVar(model[index][1])
+function has_constraint_filter(cache::VariableCache, ::Type{<:MOI.ZeroOne})
+    return cache.variable_type == BINARY
 end
 
-#=
-    Integer constraints
-=#
+function check_conflicting_constraint(cache::VariableCache, set::MOI.ZeroOne)
+    if !(cache.variable_type == CONTINUOUS)
+        throw_conflicting_variable_type(MOI.ZeroOne, cache.variable_type)
+    end
+    return
+end
+
+###
+### SingleVariable in Integer
+###
+### Conflicts with ZeroOne, Semicontinuous, and Semiinteger constraints.
 
 function MOI.add_constraint(model::LinQuadOptimizer, variable::SinVar, set::MOI.Integer)
     __assert_supported_constraint__(model, SinVar, MOI.Integer)
-    variable_type = model.variable_type[variable.variable]
-    if variable_type != CONTINUOUS
-        error("Cannot make variable integer because it is $(variable_type).")
-    end
-    model.variable_type[variable.variable] = INTEGER
-    change_variable_types!(model, [get_column(model, variable)],
-                           [backend_type(model, set)])
-    model.last_constraint_reference += 1
-    index = SVCI{MOI.Integer}(model.last_constraint_reference)
-    dict = constrdict(model, index)
-    dict[index] = variable.variable
+    cache = variable_cache(model, variable)
+    check_conflicting_constraint(cache, set)
+    cache.variable_type = INTEGER
+    change_variable_types!(model, [cache.column], [backend_type(model, set)])
     make_problem_type_integer(model)
-    return index
+    return constraint_index(variable, set)
 end
 
 function MOI.delete(model::LinQuadOptimizer, index::SVCI{MOI.Integer})
     __assert_valid__(model, index)
-    delete_constraint_name(model, index)
-    dict = constrdict(model, index)
-    variable = dict[index]
-    model.variable_type[variable] = CONTINUOUS
-    change_variable_types!(model, [get_column(model, variable)],
-                           [backend_type(model, Val{:Continuous}())])
-    delete!(dict, index)
+    cache = variable_cache(model, index)
+    cache.variable_type = CONTINUOUS
+    change_variable_types!(
+        model, [cache.column], [backend_type(model, Val{:Continuous}())])
     if !has_integer(model)
         make_problem_type_continuous(model)
     end
@@ -286,67 +428,94 @@ function MOI.get(::LinQuadOptimizer, ::MOI.ConstraintSet, ::SVCI{MOI.Integer})
     return MOI.Integer()
 end
 
-function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintFunction,
-                 index::SVCI{MOI.Integer})
-    return SinVar(model[index])
+function has_constraint_filter(cache::VariableCache, ::Type{<:MOI.Integer})
+    return cache.variable_type == INTEGER
 end
 
-#=
-    Semicontinuous / Semiinteger constraints
-=#
-const SEMI_TYPES = Union{MOI.Semicontinuous{Float64}, MOI.Semiinteger{Float64}}
-variable_type_(::Type{<:MOI.Semicontinuous}) = SEMI_CONTINUOUS
-variable_type_(::Type{<:MOI.Semiinteger}) = SEMI_INTEGER
-function MOI.add_constraint(model::LinQuadOptimizer, variable::SinVar, set::S) where S <: SEMI_TYPES
-    __assert_supported_constraint__(model, SinVar, S)
-    variable_type = model.variable_type[variable.variable]
-    if variable_type != CONTINUOUS
-        error("Cannot make variable $(S) because it is $(variable_type).")
+function check_conflicting_constraint(cache::VariableCache, set::MOI.Integer)
+    if !(cache.variable_type == CONTINUOUS)
+        throw_conflicting_variable_type(MOI.Integer, cache.variable_type)
     end
-    model.variable_type[variable.variable] = variable_type_(S)
-    column = get_column(model, variable)
-    change_variable_types!(model, [column], [backend_type(model, set)])
-    change_variable_bounds!(model,
-        [column, column],
-        [set.lower, set.upper],
-        [backend_type(model, Val{:Lowerbound}()),
-         backend_type(model, Val{:Upperbound}())]
-    )
-    model.last_constraint_reference += 1
-    index = SVCI{S}(model.last_constraint_reference)
-    dict = constrdict(model, index)
-    dict[index] = variable.variable
-    make_problem_type_integer(model)
-    return index
+    return
 end
 
-function MOI.delete(model::LinQuadOptimizer, index::SVCI{<:SEMI_TYPES})
-    __assert_valid__(model, index)
-    delete_constraint_name(model, index)
-    dict = constrdict(model, index)
-    variable = dict[index]
-    column = get_column(model, variable)
-    model.variable_type[variable] = CONTINUOUS
-    change_variable_types!(model, [column], [backend_type(model, Val{:Continuous}())])
-    change_variable_bounds!(model,
-        [column, column],
-        [-Inf, Inf],
-        [backend_type(model, Val{:Lowerbound}()),
-         backend_type(model, Val{:Upperbound}())]
+###
+### SingleVariable in Semicontinuous, Semiinteger
+###
+### These constraints conflict with all other SingleVariable-in-X constraints.
+
+const SEMI_TYPES = Union{MOI.Semicontinuous{Float64}, MOI.Semiinteger{Float64}}
+
+variable_type(::MOI.Semicontinuous) = SEMI_CONTINUOUS
+variable_type(::MOI.Semiinteger) = SEMI_INTEGER
+
+function set_cache(cache::VariableCache, set::SEMI_TYPES)
+    cache.lower = set.lower
+    cache.upper = set.upper
+    cache.bound_type = FREE
+    cache.variable_type = variable_type(set)
+    return
+end
+
+function unset_cache(cache::VariableCache, ::Type{<:SEMI_TYPES})
+    cache.lower = -Inf
+    cache.upper = Inf
+    cache.variable_type = CONTINUOUS
+    return
+end
+
+function MOI.add_constraint(model::LinQuadOptimizer, variable::SinVar, set::SEMI_TYPES)
+    __assert_supported_constraint__(model, SinVar, typeof(set))
+    cache = variable_cache(model, variable)
+    check_conflicting_constraint(cache, set)
+    set_cache(cache, set)
+    change_variable_types!(model, [cache.column], [backend_type(model, set)])
+    change_variable_bounds!(
+        model,
+        [cache.column, cache.column],
+        [set.lower, set.upper],
+        [backend_type(model, Val{:Lowerbound}()), backend_type(model, Val{:Upperbound}())]
     )
-    delete!(dict, index)
+    make_problem_type_integer(model)
+    return constraint_index(variable, set)
+end
+
+function MOI.delete(model::LinQuadOptimizer, index::SVCI{S}) where {S<:SEMI_TYPES}
+    __assert_valid__(model, index)
+    cache = variable_cache(model, index)
+    unset_cache(cache, S)
+    change_variable_types!(model, [cache.column], [backend_type(model, Val{:Continuous}())])
+    change_variable_bounds!(
+        model,
+        [cache.column, cache.column],
+        [-Inf, Inf],
+        [backend_type(model, Val{:Lowerbound}()), backend_type(model, Val{:Upperbound}())]
+    )
     if !has_integer(model)
         make_problem_type_continuous(model)
     end
 end
 
-function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintSet, index::SVCI{S}) where S <: SEMI_TYPES
-    dict = constrdict(model, index)
-    column = get_column(model, dict[index])
-    return S(get_variable_lowerbound(model, column),
-             get_variable_upperbound(model, column))
+function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintSet, index::SVCI{S}) where {S<:SEMI_TYPES}
+    cache = variable_cache(model, index)
+    return S(cache.lower, cache.upper)
 end
 
-function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintFunction, index::SVCI{<:SEMI_TYPES})
-    return SinVar(model[index])
+function has_constraint_filter(cache::VariableCache, ::Type{<:MOI.Semicontinuous})
+    return cache.variable_type == SEMI_CONTINUOUS
+end
+
+function has_constraint_filter(cache::VariableCache, ::Type{<:MOI.Semiinteger})
+    return cache.variable_type == SEMI_INTEGER
+end
+
+function check_conflicting_constraint(cache::VariableCache, set::SEMI_TYPES)
+    if !(cache.variable_type == CONTINUOUS)
+        throw_conflicting_variable_type(typeof(set), cache.variable_type)
+    elseif cache.lower != -Inf
+        throw_conflicting_lower_bound(typeof(set))
+    elseif cache.upper != Inf
+        throw_conflicting_upper_bound(typeof(set))
+    end
+    return
 end

--- a/src/constraints/vectoraffine.jl
+++ b/src/constraints/vectoraffine.jl
@@ -112,7 +112,7 @@ of this function.
 """
 function _replace_with_matching_sparsity!(model::LinQuadOptimizer, previous::VecLin, replacement::VecLin, constraint_indices)
     rows = [constraint_indices[t.output_index] for t in previous.terms]
-    cols = [model.variable_mapping[t.scalar_term.variable_index] for t in previous.terms]
+    cols = [get_column(model, t.scalar_term.variable_index) for t in previous.terms]
     coefs = MOI.coefficient.(replacement.terms)
     change_matrix_coefficients!(model, rows, cols, coefs)
 end
@@ -137,13 +137,13 @@ the sparsity patterns match, the zeroing-out step can be skipped.
 function _replace_with_different_sparsity!(model::LinQuadOptimizer, previous::VecLin, replacement::VecLin, constraint_indices)
     # First, zero out the old constraint function terms
     rows = [constraint_indices[t.output_index] for t in previous.terms]
-    cols = [model.variable_mapping[t.scalar_term.variable_index] for t in previous.terms]
+    cols = [get_column(model, t.scalar_term.variable_index) for t in previous.terms]
     coefs = fill(0.0, length(previous.terms))
     change_matrix_coefficients!(model, rows, cols, coefs)
 
     # Next, set the new constraint function terms
     rows = [constraint_indices[t.output_index] for t in replacement.terms]
-    cols = [model.variable_mapping[t.scalar_term.variable_index] for t in replacement.terms]
+    cols = [get_column(model, t.scalar_term.variable_index) for t in replacement.terms]
     coefs = MOI.coefficient.(replacement.terms)
     change_matrix_coefficients!(model, rows, cols, coefs)
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -148,9 +148,10 @@ is_binding(set::EQ, value::Float64) = isapprox(set.value, value)
 is_binding(set::IV, value::Float64) = isapprox(set.lower, value) || isapprox(set.upper, value)
 
 function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintDual, index::SVCI{<: LinSets})
-    column = get_column(model, model[index])
-    # the variable reduced cost is only the constraint dual if the bound is active,
-    # or it might be a dual ray
+    cache = variable_cache(model, index)
+    column = cache.column
+    # The variable reduced cost is only the constraint dual if the bound is
+    # active, or it might be a dual ray.
     if model.dual_status == MOI.INFEASIBILITY_CERTIFICATE
         return model.variable_dual_solution[column]
     else
@@ -173,8 +174,8 @@ end
 =#
 
 function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintPrimal, index::SVCI{<: LinSets})
-    column = get_column(model, model[index])
-    return model.variable_primal_solution[column]
+    cache = variable_cache(model, index)
+    return model.variable_primal_solution[cache.column]
 end
 
 function MOI.get(model::LinQuadOptimizer, ::MOI.ConstraintPrimal,

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -96,7 +96,7 @@ function MOI.add_variable(model::LinQuadOptimizer)
     add_variables!(model, 1)
     model.last_variable_reference += 1
     index = MOI.VariableIndex(model.last_variable_reference)
-    model.variable_mapping[index] = VariableCache(
+    model.variable_cache[index] = VariableCache(
         column = MOI.get(model, MOI.NumberOfVariables()),
         lower = -Inf,
         upper = Inf,
@@ -123,7 +123,7 @@ function MOI.add_variables(model::LinQuadOptimizer, number_to_add::Int)
         model.last_variable_reference += 1
         index = MOI.VariableIndex(model.last_variable_reference)
         push!(variable_indices, index)
-        model.variable_mapping[index] = VariableCache(
+        model.variable_cache[index] = VariableCache(
             column = previous_vars + i,
             lower = -Inf,
             upper = Inf,
@@ -143,7 +143,7 @@ end
 =#
 
 function MOI.is_valid(model::LinQuadOptimizer, index::MOI.VariableIndex)
-    return haskey(model.variable_mapping, index)
+    return haskey(model.variable_cache, index)
 end
 
 #=
@@ -163,10 +163,10 @@ function MOI.delete(model::LinQuadOptimizer, index::MOI.VariableIndex)
     deleteat!(model.variable_references, column)
     # Delete from reverse name dictionary.
     delete!(model.variable_names_rev, cache.name)
-    # Delete from variable_mapping.
-    delete!(model.variable_mapping, index)
+    # Delete from variable_cache.
+    delete!(model.variable_cache, index)
     # Decrement the column index of all other variables.
-    for (variable, cache_2) in model.variable_mapping
+    for (variable, cache_2) in model.variable_cache
         if cache_2.column > column
             cache_2.column -= 1
         end

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1,13 +1,14 @@
 #=
     Helper functions
 =#
+
 """
     get_column(model::LinQuadOptimizer, index::MOI.VariableIndex)
 
 Return the column of the variable `index` in `model`.
 """
-function get_column(model::LinQuadOptimizer, index::VarInd)
-    return model.variable_mapping[index]
+function get_column(model::LinQuadOptimizer, index::MOI.VariableIndex)
+    return variable_cache(model, index).column
 end
 
 """
@@ -25,11 +26,7 @@ end
 =#
 MOI.supports(::LinQuadOptimizer, ::MOI.VariableName, ::Type{VarInd}) = true
 function MOI.get(model::LinQuadOptimizer, ::MOI.VariableName, index::VarInd)
-    if haskey(model.variable_names, index)
-        return model.variable_names[index]
-    else
-        return ""
-    end
+    return variable_cache(model, index).name
 end
 
 # The rules for MOI are:
@@ -38,26 +35,21 @@ end
 # So we need to store two things.
 # 1. a mapping from VariableIndex -> Name
 # 2. a reverse mapping from Name -> set of VariableIndex's with that name
-function MOI.set(model::LinQuadOptimizer,
-                 ::MOI.VariableName, index::VarInd, name::String)
-    if haskey(model.variable_names, index)
-        # This variable already has a name, we must be changing it.
-        current_name = model.variable_names[index]
+function MOI.set(model::LinQuadOptimizer, ::MOI.VariableName,
+                 index::MOI.VariableIndex, name::String)
+    cache = variable_cache(model, index)
+    current_name = cache.name
+    cache.name = name
+    if current_name != ""
         # Remove `index` from the set of current name.
         pop!(model.variable_names_rev[current_name], index)
     end
     if name != ""
-        # We're changing the name to something non-default, so store it.
-        model.variable_names[index] = name
+        # Name is non-default, so store the reverse look-up.
         if !haskey(model.variable_names_rev, name)
-            model.variable_names_rev[name] = Set{VarInd}()
+            model.variable_names_rev[name] = Set{MOI.VariableIndex}()
         end
         push!(model.variable_names_rev[name], index)
-    else
-        # We're changing the name to the default, so we don't store it. Note
-        # that if `model.variable_names` doesn't have a key `index`, this does
-        # nothing.
-        delete!(model.variable_names, index)
     end
     return
 end
@@ -75,7 +67,7 @@ function MOI.get(model::LinQuadOptimizer, ::Type{MOI.VariableIndex}, name::Strin
             error("Cannot get variable because the name $(name) is a duplicate.")
         end
     end
-    return nothing
+    return
 end
 
 #=
@@ -102,14 +94,19 @@ end
 
 function MOI.add_variable(model::LinQuadOptimizer)
     add_variables!(model, 1)
-    # assumes we add columns linearly
     model.last_variable_reference += 1
-    index = VarInd(model.last_variable_reference)
-    model.variable_mapping[index] = MOI.get(model, MOI.NumberOfVariables())
+    index = MOI.VariableIndex(model.last_variable_reference)
+    model.variable_mapping[index] = VariableCache(
+        column = MOI.get(model, MOI.NumberOfVariables()),
+        lower = -Inf,
+        upper = Inf,
+        variable_type = CONTINUOUS,
+        bound_type = FREE,
+        name = ""
+    )
     push!(model.variable_references, index)
     push!(model.variable_primal_solution, NaN)
     push!(model.variable_dual_solution, NaN)
-    model.variable_type[index] = CONTINUOUS
     return index
 end
 
@@ -120,20 +117,23 @@ end
 function MOI.add_variables(model::LinQuadOptimizer, number_to_add::Int)
     previous_vars = MOI.get(model, MOI.NumberOfVariables())
     add_variables!(model, number_to_add)
-    variable_indices = VarInd[]
+    variable_indices = MOI.VariableIndex[]
     sizehint!(variable_indices, number_to_add)
     for i in 1:number_to_add
-        # assumes we add columns linearly
         model.last_variable_reference += 1
-        index = VarInd(model.last_variable_reference)
+        index = MOI.VariableIndex(model.last_variable_reference)
         push!(variable_indices, index)
-        # m.last_variable_reference might not be the column if we have
-        # deleted variables.
-        model.variable_mapping[index] = previous_vars + i
+        model.variable_mapping[index] = VariableCache(
+            column = previous_vars + i,
+            lower = -Inf,
+            upper = Inf,
+            variable_type = CONTINUOUS,
+            bound_type = FREE,
+            name = ""
+        )
         push!(model.variable_references, index)
         push!(model.variable_primal_solution, NaN)
         push!(model.variable_dual_solution, NaN)
-        model.variable_type[index] = CONTINUOUS
     end
     return variable_indices
 end
@@ -142,78 +142,57 @@ end
     Check if reference is valid
 =#
 
-function MOI.is_valid(model::LinQuadOptimizer, index::VarInd)
-    if haskey(model.variable_mapping, index)
-        column = get_column(model, index)
-        if 1 <= column <= MOI.get(model, MOI.NumberOfVariables())
-            return true
-        end
-    end
-    return false
+function MOI.is_valid(model::LinQuadOptimizer, index::MOI.VariableIndex)
+    return haskey(model.variable_mapping, index)
 end
 
 #=
     Delete a variable
 =#
 
-function MOI.delete(model::LinQuadOptimizer, index::VarInd)
+function MOI.delete(model::LinQuadOptimizer, index::MOI.VariableIndex)
     __assert_valid__(model, index)
-    column = get_column(model, index)
+    cache = variable_cache(model, index)
+    column = cache.column
+    # Delete variables in internal model.
     delete_variables!(model, column, column)
-    # delete from problem
-    deleteat!(model.variable_references, column)
-    delete!(model.variable_type, index)
+    # Delete solution cache.
     deleteat!(model.variable_primal_solution, column)
     deleteat!(model.variable_dual_solution, column)
-    deleteref!(model.variable_mapping, column, index)
-    # delete name if not ""
-    if haskey(model.variable_names, index)
-        name = model.variable_names[index]
-        delete!(model.variable_names_rev, name)
-        delete!(model.variable_names, index)
-    end
-    # Delete any bounds (deleting from a dict without the key does nothing).
-    constraint_map = cmap(model)
-    delete_from_dictionary_by_value(constraint_map.upper_bound, index)
-    delete_from_dictionary_by_value(constraint_map.lower_bound, index)
-    delete_from_dictionary_by_value(constraint_map.fixed_bound, index)
-    delete_from_dictionary_by_value(constraint_map.interval_bound, index)
-    return
-end
-
-"""
-    delete_from_dictionary_by_value(dict::Dict{K, V}, index::V)
-
-Delete the entries of a dictionary where the value of a `key=>value` pair is
-equal to `index`.
-
-This is used to remove bounds when deleting a variable.
-"""
-function delete_from_dictionary_by_value(dict::Dict{K, V}, index::V) where {K, V}
-    for (key, value) in dict
-        if value == index
-            delete!(dict, key)
+    # Delete from ordered list of variables.
+    deleteat!(model.variable_references, column)
+    # Delete from reverse name dictionary.
+    delete!(model.variable_names_rev, cache.name)
+    # Delete from variable_mapping.
+    delete!(model.variable_mapping, index)
+    # Decrement the column index of all other variables.
+    for (variable, cache_2) in model.variable_mapping
+        if cache_2.column > column
+            cache_2.column -= 1
         end
     end
+    return
 end
 
 #=
     MIP starts
 =#
-function MOI.supports(
-        ::LinQuadOptimizer, ::MOI.VariablePrimalStart, ::Type{VarInd})
+
+function MOI.supports(::LinQuadOptimizer, ::MOI.VariablePrimalStart,
+                      ::Type{MOI.VariableIndex})
     return false
 end
 
 function MOI.set(model::LinQuadOptimizer, ::MOI.VariablePrimalStart,
-                  indices::Vector{VarInd}, values::Vector{Float64})
+                 indices::Vector{MOI.VariableIndex}, values::Vector{Float64})
     if !MOI.supports(model, MOI.VariablePrimalStart(), MOI.VariableIndex)
         throw(MOI.UnsupportedAttribute(MOI.VariablePrimalStart()))
     end
     add_mip_starts!(model, get_column.(Ref(model), indices), values)
+    return
 end
 
 function MOI.set(model::LinQuadOptimizer, ::MOI.VariablePrimalStart,
-                  index::VarInd, value::Float64)
+                 index::MOI.VariableIndex, value::Float64)
     MOI.set(model, MOI.VariablePrimalStart(), [index], [value])
 end


### PR DESCRIPTION
JuMPing the gun on https://github.com/JuliaOpt/MathOptInterface.jl/issues/570 to see if it helps some performance issues I'm having.

Sorry for the scary diff. 

Once Scalarize bridges land, we can tear out a lot of the complexity in the LQOI code. 

We should also consider refactoring the solver interface to reduce the number of vector methods in favor of singular ones. That would avoid lots of unneeded vector allocations.

<s>This will break CPLEX and maybe Xpress since it no longer caches variable bounds on the LQOI side of things. Solver-specific behavior (like Xpress over-writing user bounds) should be handled by the solvers.</s>