### PR TITLE
Improved constraint deletion performance by separating functions

### DIFF
--- a/src/LinQuadOptInterface.jl
+++ b/src/LinQuadOptInterface.jl
@@ -127,18 +127,37 @@ function shift_references_after_delete_affine!(m, row)
 
 end
 
-# The following two functions d
+# The following two functions depend on the implimentation of Dict having the field vals
 function _shift_references_after_delete_scalar!(scalar::Dict, row)
     vals = scalar.vals
+    # This function checks if the value is greater the than row which is being deleted
+    # If it is it shift the value down by one.
     f(v,r)= v > r ? v - 1 : v
+
+    ## The broadcast! below is equivilent to the following for loop
+    # for n in 1:length(vals)
+    #     vals[n]=f(vals[n],row)
+    # end
+    ## Further more broadcast!(f, vals, vals, row) is the nonallocating version
+    ## of vals[:]. = f.(vals[:], row)
     broadcast!(f, vals, vals, row)
+
+
 end
 
 function _shift_references_after_delete_vector!(vector::Dict, row)
     vals = vector.vals
+    # This function checks if the value is greater the than row which is being deleted
+    # If it is it shift the value down by one.
     f(v,r)= v > r ? v - 1 : v
     for n in 1:length(vals)
         if isassigned(vals,n)
+            ## The broadcast! below is equivilent to the following for loop
+            # for i in 1:length(vals[n])
+            #     vals[n][i] = f(vals[n][i], row)
+            # end
+            ## Further more broadcast!(f, vals[n], vals[n], row) is the nonallocating version
+            ## of vals[n][:] .= f.(vals[n][:], row)
             broadcast!(f, vals[n], vals[n], row)
         end
     end

--- a/src/LinQuadOptInterface.jl
+++ b/src/LinQuadOptInterface.jl
@@ -130,35 +130,19 @@ end
 # The following two functions depend on the implementation of Dict having the field vals
 function _shift_references_after_delete_scalar!(scalar::Dict, row)
     vals = scalar.vals
-    # This function checks if the value is greater the than row which is being deleted
-    # If it is it shift the value down by one.
-    f(v,r)= v > r ? v - 1 : v
-
-    ## The broadcast! below is equivilent to the following for loop
-    # for n in 1:length(vals)
-    #     vals[n]=f(vals[n],row)
-    # end
-    ## Further more broadcast!(f, vals, vals, row) is the nonallocating version
-    ## of vals[:]. = f.(vals[:], row)
-    broadcast!(f, vals, vals, row)
-
-
+    for n in 1:length(vals)
+        @inbounds vals[n] = vals[n] > row ? vals[n] - 1 : vals[n]
+    end
 end
 
 function _shift_references_after_delete_vector!(vector::Dict, row)
     vals = vector.vals
-    # This function checks if the value is greater the than row which is being deleted
-    # If it is it shift the value down by one.
-    f(v,r)= v > r ? v - 1 : v
     for n in 1:length(vals)
         if isassigned(vals,n)
-            ## The broadcast! below is equivilent to the following for loop
-            # for i in 1:length(vals[n])
-            #     vals[n][i] = f(vals[n][i], row)
-            # end
-            ## Further more broadcast!(f, vals[n], vals[n], row) is the nonallocating version
-            ## of vals[n][:] .= f.(vals[n][:], row)
-            broadcast!(f, vals[n], vals[n], row)
+            vec=vals[n]
+            for n in 1:length(vec)
+                @inbounds vec[n] = vec[n] > row ? vec[n] - 1 : vec[n]
+            end
         end
     end
 end

--- a/src/LinQuadOptInterface.jl
+++ b/src/LinQuadOptInterface.jl
@@ -127,7 +127,8 @@ function shift_references_after_delete_affine!(m, row)
 
 end
 
-# The following two functions depend on the implementation of Dict having the field vals
+# This functions loops through the hidden `.vals` field of the `scalar`
+# dictionary and  decreases the value by 1 if it is greater than `row`.
 function _shift_references_after_delete_scalar!(scalar::Dict, row)
     vals = scalar.vals
     for n in 1:length(vals)
@@ -135,6 +136,9 @@ function _shift_references_after_delete_scalar!(scalar::Dict, row)
     end
 end
 
+# This functions loops through the hidden `.vals` field of the `vector`
+# dictionary and for each value of the array decreases the value by 1 if it is
+# greater than `row`.
 function _shift_references_after_delete_vector!(vector::Dict, row)
     vals = vector.vals
     for n in 1:length(vals)

--- a/src/LinQuadOptInterface.jl
+++ b/src/LinQuadOptInterface.jl
@@ -146,11 +146,14 @@ if !(hasmethod(Base.map!,Tuple{Any,Base.ValueIterator{<:Dict}}))
 end
 
 
+# This function takes the Dict which provides a map to the matrix row and shifts
+# every row index that is greater than the deleted row down by one
 function _shift_references_after_delete_scalar!(scalar::Dict, row)
     map!(v -> v > row ? v-1 : v, values(scalar))
 end
 
-
+# This is the same as the function above but because the Dict points to vectors
+# of indexes we have to modify the function to account for that 
 function _shift_references_after_delete_vector!(vector::Dict, row)
     # This is slightly confusions but it is similar to the above function but with an inner map on a vector
     map!(vec -> map!(v -> v > row ? v-1 : v, vec, vec), values(vector))
@@ -390,8 +393,7 @@ end
 
 # a useful helper function
 function deleteref!(dict::Dict, i::Int, ref)
-    f(v,r) = v > r ? v - 1 : v
-    broadcast!(f, dict.vals, dict.vals, i)
+    map!(v -> v > i ? v - 1 : v, values(dict))
     delete!(dict, ref)
 end
 

--- a/src/LinQuadOptInterface.jl
+++ b/src/LinQuadOptInterface.jl
@@ -127,7 +127,7 @@ function shift_references_after_delete_affine!(m, row)
 
 end
 
-# The following two functions depend on the implimentation of Dict having the field vals
+# The following two functions depend on the implementation of Dict having the field vals
 function _shift_references_after_delete_scalar!(scalar::Dict, row)
     vals = scalar.vals
     # This function checks if the value is greater the than row which is being deleted

--- a/src/LinQuadOptInterface.jl
+++ b/src/LinQuadOptInterface.jl
@@ -130,6 +130,9 @@ end
 # This functions loops through the hidden `.vals` field of the `scalar`
 # dictionary and  decreases the value by 1 if it is greater than `row`.
 function _shift_references_after_delete_scalar!(scalar::Dict, row)
+    # If this assertion fails it means that the Dict type has change its implementation.
+    # In julia v1.2 this should be changed to @assert hasfield(Dict,:vals).
+    @assert isdefined(scalar,:vals)
     vals = scalar.vals
     for n in 1:length(vals)
         @inbounds vals[n] = vals[n] > row ? vals[n] - 1 : vals[n]
@@ -140,6 +143,9 @@ end
 # dictionary and for each value of the array decreases the value by 1 if it is
 # greater than `row`.
 function _shift_references_after_delete_vector!(vector::Dict, row)
+    # If this assertion fails it means that the Dict type has change its implementation.
+    # In julia v1.2 this should be changed to @assert hasfield(Dict,:vals).
+    @assert isdefined(vector,:vals)
     vals = vector.vals
     for n in 1:length(vals)
         if isassigned(vals,n)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,7 +41,11 @@ end
 
     @testset "Linear tests" begin
         config = MOIT.TestConfig(solve=false)
-        MOIT.contlineartest(solver, config)
+        MOIT.contlineartest(solver, config, [
+            # partial_start requires VariablePrimalStart to be implemented by the
+            # solver.
+            "partial_start"
+        ])
         config = MOIT.TestConfig()
         include("contlinear.jl")
         set_linear1test_solutions!(solver)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,11 +41,8 @@ end
 
     @testset "Linear tests" begin
         config = MOIT.TestConfig(solve=false)
-        MOIT.contlineartest(solver, config, [
-            # partial_start requires VariablePrimalStart to be implemented by the
-            # solver.
-            "partial_start"
-        ])
+        # Exclude partial_start since VariablePrimalStart not implemented.
+        MOIT.contlineartest(solver, config, ["partial_start"])
         config = MOIT.TestConfig()
         include("contlinear.jl")
         set_linear1test_solutions!(solver)


### PR DESCRIPTION
This change improves the performance of constraint deletion by more than 6x.

Using the following benchmark:
```julia
using JuMP
using GLPK
using Clp
using BenchmarkTools

function constraint_deletion_benchmark(opt_package,num_variables,solver_opts=NamedTuple())
    model = Model(with_optimizer(opt_package.Optimizer; solver_opts...))

    vars=@variable(model,[i = 1:num_variables])

    cons=@constraint(model,vars .<= 1)

    for con in cons
        delete(model,con)
    end

    cons=@constraint(model,vars .<= 1)
    @objective(model,Max,sum(vars))
    optimize!(model)

    for con in cons
        delete(model,con)
    end
end

#------
@benchmark constraint_deletion_benchmark(GLPK,1000)
@benchmark constraint_deletion_benchmark(Clp,1000,(LogLevel=0,))

```
master:
```julia
julia> @benchmark constraint_deletion_benchmark(GLPK,1000)
BenchmarkTools.Trial: 
  memory estimate:  78.52 MiB
  allocs estimate:  3852740
  --------------
  minimum time:     295.216 ms (4.87% GC)
  median time:      327.834 ms (4.88% GC)
  mean time:        328.450 ms (6.63% GC)
  maximum time:     416.230 ms (28.00% GC)
  --------------
  samples:          16
  evals/sample:     1

julia> @benchmark constraint_deletion_benchmark(Clp,1000,(LogLevel=0,))
BenchmarkTools.Trial: 
  memory estimate:  78.94 MiB
  allocs estimate:  3854763
  --------------
  minimum time:     289.888 ms (5.43% GC)
  median time:      323.338 ms (4.64% GC)
  mean time:        326.543 ms (6.63% GC)
  maximum time:     423.405 ms (28.99% GC)
  --------------
  samples:          16
  evals/sample:     1
```

ndinsmore:row_deletion_perf:
```julia
julia> @benchmark constraint_deletion_benchmark(GLPK,1000)
BenchmarkTools.Trial: 
  memory estimate:  5.98 MiB
  allocs estimate:  118130
  --------------
  minimum time:     40.884 ms (0.00% GC)
  median time:      50.572 ms (0.00% GC)
  mean time:        60.356 ms (2.37% GC)
  maximum time:     231.075 ms (3.69% GC)
  --------------
  samples:          83
  evals/sample:     1

julia> @benchmark constraint_deletion_benchmark(Clp,1000,(LogLevel=0,))
BenchmarkTools.Trial: 
  memory estimate:  6.41 MiB
  allocs estimate:  120153
  --------------
  minimum time:     30.155 ms (0.00% GC)
  median time:      43.865 ms (0.00% GC)
  mean time:        57.698 ms (3.26% GC)
  maximum time:     515.472 ms (1.47% GC)
  --------------
  samples:          87
  evals/sample:     1
```