### PR TITLE
CSRmatrix improvement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: julia
 os:
   - linux
 julia:
-  - 0.7
   - 1.0
   - 1.1
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: julia
 os:
   - linux
 julia:
-  - 0.6
   - 0.7
   - 1.0
+  - 1.1
   - nightly
 matrix:
   allow_failures:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.6
+julia 0.7
 MathOptInterface 0.8 0.9
 Compat 0.59

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   matrix:
-  - julia_version: 0.6
   - julia_version: 0.7
   - julia_version: 1.0
+  - julia_version: 1.1
 
 platform:
   - x86 # 32-bit

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -182,21 +182,14 @@ end
 """
     CSRMatrix{T}
 
-Matrix given in compressed sparse row (CSR) format.
+Type alias for Adjoint{T,SparseMatrixCSC{T,Int}} where T, whichc allows for the
+    efficient storage of CSR sparse matrix
 
-`CSRMatrix` is analgous to the structure in Julia's `SparseMatrixCSC` but with
-the rows and columns flipped. It contains three vectors:
- - `row_pointers` is a vector pointing to the start of each row in
-    `columns` and `coefficients` this should end with a `length(coefficients)+1`;
- - `columns` is a vector of column numbers; and
- - `coefficients` is a vector of corresponding nonzero values.
-
-The length of `row_pointers` is the number of rows in the matrix + 1.
-
-This struct is not a subtype of `AbstractSparseMatrix` as it is intended to be a
-collection of the three vectors as they are required by some solvers.
-Solvers such as Gurobi may need to trim the last index off of row_pointers.
-It is not intended to be used for general computation.
+Please use the following interface to access this data incase model is changed in future
+ - `row_pointers(mat)` returns that sparse row_pointer vector see description
+    which has a length of rows+1
+ - `colvals` this is the column version of rowvals(SparseMatrixCSC)
+ - `coefficients` this is the equivilent to nonzeros(SparseMatrixCSC)
 """
 
 const CSRMatrix{T} = Adjoint{T,SparseMatrixCSC{T,Int}} where T
@@ -207,12 +200,10 @@ function CSRMatrix{T}(row_pointers, columns, coefficients) where T
     SparseMatrixCSC{T,Int}(maximum(columns), length(row_pointers)-1, row_pointers, columns, coefficients)'
 end
 
-
 #   Move access to an interface so that if we want to change type definition we can.
 colvals(mat::CSRMatrix) = rowvals(mat')
 row_pointers(mat::CSRMatrix) = mat'.colptr  # This is the only way to get at colptrs without recreating it
 row_nonzeros(mat::CSRMatrix) = nonzeros(mat')
-
 
 #=
     Below we add constraints.

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -201,18 +201,6 @@ It is not intended to be used for general computation.
 
 const CSRMatrix{T} = Adjoint{T,SparseMatrixCSC{T,Int}} where T
 
-# struct CSRMatrix{T}
-#     # This whole definition should really be replaced by and Adjoint{SparseMatrixCSC}
-#     row_pointers::Vector{Int}
-#     columns::Vector{Int}
-#     coefficients::Vector{T}
-#     function CSRMatrix{T}(row_pointers, columns, coefficients) where T
-#         @assert length(columns) == length(coefficients)
-#         @assert length(columns) + 1 == row_pointers[end]
-#         new(row_pointers, columns, coefficients)
-#     end
-# end
-
 function CSRMatrix{T}(row_pointers, columns, coefficients) where T
     @assert length(columns) == length(coefficients)
     @assert length(columns) + 1 == row_pointers[end]
@@ -224,8 +212,6 @@ end
 colvals(mat::CSRMatrix) = rowvals(mat')
 row_pointers(mat::CSRMatrix) = mat'.colptr  # This is the only way to get at colptrs without recreating it
 row_nonzeros(mat::CSRMatrix) = nonzeros(mat')
-
-
 
 
 #=

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -215,8 +215,9 @@ colvals(mat::CSRMatrix) = mat.columns
 row_pointers(mat::CSRMatrix) = mat.row_pointers
 row_nonzeros(mat::CSRMatrix) = mat.coefficients
 
+import SparseArrays: sparse
 sparse(m::CSRMatrix{T}) where T =sparse(
-    SparseMatrixCSC{Int,T}(maximum(m.columns), length(m.row_pointers)-1, m.row_pointers, m.columns, m.coefficients)'
+    SparseMatrixCSC{T,Int}(maximum(m.columns), length(m.row_pointers)-1, m.row_pointers, m.columns, m.coefficients)'
     )
 
 

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -182,7 +182,7 @@ end
 """
     CSRMatrix{T}
 
-Type alias for `Adjoint{T,SparseMatrixCSC{T,Int}} where T`, which allows for the
+Type alias for `Transpose{T,SparseMatrixCSC{T,Int}} where T`, which allows for the
     efficient storage of compressed sparse row (CSR) sparse matrix
 
 Please use the following interface to access this data incase model is changed in future
@@ -192,18 +192,18 @@ Please use the following interface to access this data incase model is changed i
  - `row_nonzeros` this is the equivilent to `nonzeros(SparseMatrixCSC)`
 """
 
-const CSRMatrix{T} = Adjoint{T,SparseMatrixCSC{T,Int}} where T
+const CSRMatrix{T} = Transpose{T,SparseMatrixCSC{T,Int}} where T
 
 function CSRMatrix{T}(row_pointers, columns, coefficients) where T
     @assert length(columns) == length(coefficients)
     @assert length(columns) + 1 == row_pointers[end]
-    SparseMatrixCSC{T,Int}(maximum(columns), length(row_pointers)-1, row_pointers, columns, coefficients)'
+    transpose(SparseMatrixCSC{T,Int}(maximum(columns), length(row_pointers)-1, row_pointers, columns, coefficients))
 end
 
 #   Move access to an interface so that if we want to change type definition we can.
-colvals(mat::CSRMatrix) = rowvals(mat')
-row_pointers(mat::CSRMatrix) = mat'.colptr  # This is the only way to get at colptrs without recreating it
-row_nonzeros(mat::CSRMatrix) = nonzeros(mat')
+colvals(mat::CSRMatrix) = rowvals(transpose(mat))
+row_pointers(mat::CSRMatrix) = transpose(mat).colptr  # This is the only way to get at colptrs without recreating it
+row_nonzeros(mat::CSRMatrix) = nonzeros(transpose(mat))
 
 #=
     Below we add constraints.

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -215,10 +215,12 @@ colvals(mat::CSRMatrix) = mat.columns
 row_pointers(mat::CSRMatrix) = mat.row_pointers
 row_nonzeros(mat::CSRMatrix) = mat.coefficients
 
+sparse(m::CSRMatrix{T}) where T =sparse(
+    SparseMatrixCSC{Int,T}(maximum(m.columns), length(m.row_pointers)-1, m.row_pointers, m.columns, m.coefficients)'
+    )
+
+
 # Lets also depreciate that use of direct property access
-@deprecate getproperty(mat::CSRMatrix, :row_pointers) row_pointers(mat) false
-@deprecate getproperty(mat::CSRMatrix, :columns) colvals(mat) false
-@deprecate getproperty(mat::CSRMatrix, :coefficients) row_nonzeros(mat) false
 
 
 #=

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -182,14 +182,14 @@ end
 """
     CSRMatrix{T}
 
-Type alias for Adjoint{T,SparseMatrixCSC{T,Int}} where T, whichc allows for the
-    efficient storage of CSR sparse matrix
+Type alias for `Adjoint{T,SparseMatrixCSC{T,Int}} where T`, which allows for the
+    efficient storage of compressed sparse row (CSR) sparse matrix
 
 Please use the following interface to access this data incase model is changed in future
  - `row_pointers(mat)` returns that sparse row_pointer vector see description
     which has a length of rows+1
- - `colvals` this is the column version of rowvals(SparseMatrixCSC)
- - `coefficients` this is the equivilent to nonzeros(SparseMatrixCSC)
+ - `colvals` this is the column version of `rowvals(SparseMatrixCSC)`
+ - `row_nonzeros` this is the equivilent to `nonzeros(SparseMatrixCSC)`
 """
 
 const CSRMatrix{T} = Adjoint{T,SparseMatrixCSC{T,Int}} where T

--- a/src/constraints/scalaraffine.jl
+++ b/src/constraints/scalaraffine.jl
@@ -35,7 +35,7 @@ end
 function add_linear_constraint(model::LinQuadOptimizer, func::Linear, set::IV)
     columns = [get_column(model, term.variable_index) for term in func.terms]
     coefficients = [term.coefficient for term in func.terms]
-    A = CSRMatrix{Float64}([1], columns, coefficients)
+    A = CSRMatrix{Float64}([1,length(coefficients)+1], columns, coefficients)
     add_ranged_constraints!(model, A, [set.lower], [set.upper])
 end
 
@@ -45,7 +45,7 @@ function add_linear_constraint(model::LinQuadOptimizer, func::Linear, sense, rhs
     end
     columns = [get_column(model, term.variable_index) for term in func.terms]
     coefficients = [term.coefficient for term in func.terms]
-    A = CSRMatrix{Float64}([1], columns, coefficients)
+    A = CSRMatrix{Float64}([1,length(coefficients)+1], columns, coefficients)
     add_linear_constraints!(model, A, [sense], [rhs - func.constant])
 end
 
@@ -99,7 +99,7 @@ function functions_to_CSRMatrix(model::LinQuadOptimizer, functions::Vector{Linea
     # row (i - 1), storing the result in r[i]. Then we perform a cumsum on r,
     # storing the result back in r.
     num_rows = length(functions)
-    row_pointers = fill(0, num_rows)
+    row_pointers = fill(0, num_rows+1)
     row_pointers[1] = 1
     non_zero_index = 0
     for (row, func) in enumerate(functions)
@@ -117,6 +117,7 @@ function functions_to_CSRMatrix(model::LinQuadOptimizer, functions::Vector{Linea
         end
     end
     cumsum!(row_pointers, row_pointers)
+    row_pointers[end]=length(coefficients)+1
     return CSRMatrix{Float64}(row_pointers, columns, coefficients)
 end
 

--- a/src/constraints/scalaraffine.jl
+++ b/src/constraints/scalaraffine.jl
@@ -35,7 +35,7 @@ end
 function add_linear_constraint(model::LinQuadOptimizer, func::Linear, set::IV)
     columns = [get_column(model, term.variable_index) for term in func.terms]
     coefficients = [term.coefficient for term in func.terms]
-    A = CSRMatrix{Float64}([1,length(coefficients)+1], columns, coefficients)
+    A = CSRMatrix{Float64}([1, length(coefficients) + 1], columns, coefficients)
     add_ranged_constraints!(model, A, [set.lower], [set.upper])
 end
 
@@ -45,7 +45,7 @@ function add_linear_constraint(model::LinQuadOptimizer, func::Linear, sense, rhs
     end
     columns = [get_column(model, term.variable_index) for term in func.terms]
     coefficients = [term.coefficient for term in func.terms]
-    A = CSRMatrix{Float64}([1,length(coefficients)+1], columns, coefficients)
+    A = CSRMatrix{Float64}([1, length(coefficients) + 1], columns, coefficients)
     add_linear_constraints!(model, A, [sense], [rhs - func.constant])
 end
 
@@ -117,7 +117,7 @@ function functions_to_CSRMatrix(model::LinQuadOptimizer, functions::Vector{Linea
         end
     end
     cumsum!(row_pointers, row_pointers)
-    row_pointers[end]=length(coefficients)+1
+    row_pointers[end] = length(coefficients)+1
     return CSRMatrix{Float64}(row_pointers, columns, coefficients)
 end
 

--- a/src/constraints/vectoraffine.jl
+++ b/src/constraints/vectoraffine.jl
@@ -41,7 +41,7 @@ function add_linear_constraint(model::LinQuadOptimizer, func::VecLin, sense::Cch
     # row (i - 1), storing the result in r[i]. Then we perform a cumsum on r,
     # storing the result back in r.
     num_rows = length(func.constants)
-    row_pointers = fill(0, num_rows)
+    row_pointers = fill(0, num_rows+1)
     row_pointers[1] = 1
     for term in func.terms
         row = term.output_index
@@ -53,7 +53,7 @@ function add_linear_constraint(model::LinQuadOptimizer, func::VecLin, sense::Cch
         end
     end
     cumsum!(row_pointers, row_pointers)
-
+    row_pointers[end]=length(coefficients)+1
     A = CSRMatrix{Float64}(row_pointers, columns, coefficients)
     add_linear_constraints!(model, A, fill(sense, num_rows), -func.constants)
 end

--- a/src/constraints/vectorofvariables.jl
+++ b/src/constraints/vectorofvariables.jl
@@ -21,7 +21,7 @@ function MOI.add_constraint(model::LinQuadOptimizer, func::VecVar, set::S) where
     rows = get_number_linear_constraints(model)
     num_vars = MOI.dimension(set)
     add_linear_constraints!(model,
-        CSRMatrix{Float64}(collect(1:num_vars),
+        CSRMatrix{Float64}([collect(1:num_vars); num_vars+1],
                            get_column.(Ref(model), func.variables),
                            ones(num_vars)),
         fill(backend_type(model, set), num_vars),

--- a/src/constraints/vectorofvariables.jl
+++ b/src/constraints/vectorofvariables.jl
@@ -21,7 +21,7 @@ function MOI.add_constraint(model::LinQuadOptimizer, func::VecVar, set::S) where
     rows = get_number_linear_constraints(model)
     num_vars = MOI.dimension(set)
     add_linear_constraints!(model,
-        CSRMatrix{Float64}([collect(1:num_vars); num_vars+1],
+        CSRMatrix{Float64}(collect(1:num_vars+1),
                            get_column.(Ref(model), func.variables),
                            ones(num_vars)),
         fill(backend_type(model, set), num_vars),

--- a/src/mockoptimizer.jl
+++ b/src/mockoptimizer.jl
@@ -403,11 +403,11 @@ function LQOI.add_linear_constraints!(instance::MockLinQuadOptimizer, A::CSRMatr
     # quadind
     append!(instance.l_rows,addedrows)
 
-    rowvec, colvec, coefvec = A.row_pointers, A.columns, A.coefficients
+    rowvec, colvec, coefvec = row_pointers(A), colvals(A), row_nonzeros(A)
 
     rows = length(rhsvec)
     cols = size(instance.inner.A)[2]
-    push!(rowvec,length(colvec)+1)
+    # push!(rowvec,length(colvec)+1)
 
     An = Array(SparseMatrixCSC(cols,rows,rowvec,colvec,coefvec)')
 
@@ -430,10 +430,10 @@ function LQOI.add_ranged_constraints!(instance::MockLinQuadOptimizer, A::CSRMatr
     # quadind
     append!(instance.l_rows,addedrows)
 
-    rowvec, colvec, coefvec = A.row_pointers, A.columns, A.coefficients
+    rowvec, colvec, coefvec = row_pointers(A), colvals(A), row_nonzeros(A)
     rows = length(lowerbound)
     cols = size(instance.inner.A)[2]
-    push!(rowvec,length(colvec)+1)
+    # push!(rowvec,length(colvec)+1)
 
     # An = Array(sparse(rowvec,colvec,coefvec,rows,cols))
     # @show cols,rows,rowvec,colvec,coefvec

--- a/src/mockoptimizer.jl
+++ b/src/mockoptimizer.jl
@@ -407,7 +407,6 @@ function LQOI.add_linear_constraints!(instance::MockLinQuadOptimizer, A::CSRMatr
 
     rows = length(rhsvec)
     cols = size(instance.inner.A)[2]
-    # push!(rowvec,length(colvec)+1)
 
     An = Array(SparseMatrixCSC(cols,rows,rowvec,colvec,coefvec)')
 
@@ -433,10 +432,7 @@ function LQOI.add_ranged_constraints!(instance::MockLinQuadOptimizer, A::CSRMatr
     rowvec, colvec, coefvec = row_pointers(A), colvals(A), row_nonzeros(A)
     rows = length(lowerbound)
     cols = size(instance.inner.A)[2]
-    # push!(rowvec,length(colvec)+1)
 
-    # An = Array(sparse(rowvec,colvec,coefvec,rows,cols))
-    # @show cols,rows,rowvec,colvec,coefvec
     An = Array(SparseMatrixCSC(cols,rows,rowvec,colvec,coefvec)')
 
     instance.inner.A = vcat(instance.inner.A,An)


### PR DESCRIPTION
This makes a slight change to the implementation of CSRMatrix to make it more similar to a proper sparse implementation.  This is essentially making row_pointers include the index+1 pointer for the end of the last row.   
An interface has also been added to allow access to the properties of CSRMatrix. 

The reason for this for this change is to enable speed improvements in Clp