### PR TITLE
Change the Implimentation of CSRMatrix to us SparseMatrixCSC

### DIFF
--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -163,7 +163,7 @@ end
 Type alias for `Transpose{T,SparseMatrixCSC{T,Int}} where T`, which allows for the
     efficient storage of compressed sparse row (CSR) sparse matrix
 
-Please use the following interface to access this data incase model is changed in future
+Please use the following interface to access this data in case model is changed in future
  - `row_pointers(mat)` returns that sparse row_pointer vector see description
     which has a length of rows+1
  - `colvals` this is the column version of `rowvals(SparseMatrixCSC)`

--- a/src/constraints/scalaraffine.jl
+++ b/src/constraints/scalaraffine.jl
@@ -35,7 +35,7 @@ end
 function add_linear_constraint(model::LinQuadOptimizer, func::Linear, set::IV)
     columns = [get_column(model, term.variable_index) for term in func.terms]
     coefficients = [term.coefficient for term in func.terms]
-    A = CSRMatrix{Float64}([1], columns, coefficients)
+    A = CSRMatrix{Float64}([1, length(coefficients) + 1], columns, coefficients)
     add_ranged_constraints!(model, A, [set.lower], [set.upper])
 end
 
@@ -45,7 +45,7 @@ function add_linear_constraint(model::LinQuadOptimizer, func::Linear, sense, rhs
     end
     columns = [get_column(model, term.variable_index) for term in func.terms]
     coefficients = [term.coefficient for term in func.terms]
-    A = CSRMatrix{Float64}([1], columns, coefficients)
+    A = CSRMatrix{Float64}([1, length(coefficients) + 1], columns, coefficients)
     add_linear_constraints!(model, A, [sense], [rhs - func.constant])
 end
 
@@ -99,7 +99,7 @@ function functions_to_CSRMatrix(model::LinQuadOptimizer, functions::Vector{Linea
     # row (i - 1), storing the result in r[i]. Then we perform a cumsum on r,
     # storing the result back in r.
     num_rows = length(functions)
-    row_pointers = fill(0, num_rows)
+    row_pointers = fill(0, num_rows+1)
     row_pointers[1] = 1
     non_zero_index = 0
     for (row, func) in enumerate(functions)
@@ -117,6 +117,7 @@ function functions_to_CSRMatrix(model::LinQuadOptimizer, functions::Vector{Linea
         end
     end
     cumsum!(row_pointers, row_pointers)
+    row_pointers[end] = length(coefficients)+1
     return CSRMatrix{Float64}(row_pointers, columns, coefficients)
 end
 

--- a/src/constraints/vectoraffine.jl
+++ b/src/constraints/vectoraffine.jl
@@ -41,7 +41,7 @@ function add_linear_constraint(model::LinQuadOptimizer, func::VecLin, sense::Cch
     # row (i - 1), storing the result in r[i]. Then we perform a cumsum on r,
     # storing the result back in r.
     num_rows = length(func.constants)
-    row_pointers = fill(0, num_rows)
+    row_pointers = fill(0, num_rows+1)
     row_pointers[1] = 1
     for term in func.terms
         row = term.output_index
@@ -53,7 +53,7 @@ function add_linear_constraint(model::LinQuadOptimizer, func::VecLin, sense::Cch
         end
     end
     cumsum!(row_pointers, row_pointers)
-
+    row_pointers[end]=length(coefficients)+1
     A = CSRMatrix{Float64}(row_pointers, columns, coefficients)
     add_linear_constraints!(model, A, fill(sense, num_rows), -func.constants)
 end

--- a/src/constraints/vectorofvariables.jl
+++ b/src/constraints/vectorofvariables.jl
@@ -21,7 +21,7 @@ function MOI.add_constraint(model::LinQuadOptimizer, func::VecVar, set::S) where
     rows = get_number_linear_constraints(model)
     num_vars = MOI.dimension(set)
     add_linear_constraints!(model,
-        CSRMatrix{Float64}(collect(1:num_vars),
+        CSRMatrix{Float64}(collect(1:num_vars+1),
                            get_column.(Ref(model), func.variables),
                            ones(num_vars)),
         fill(backend_type(model, set), num_vars),

--- a/src/mockoptimizer.jl
+++ b/src/mockoptimizer.jl
@@ -403,11 +403,10 @@ function LQOI.add_linear_constraints!(instance::MockLinQuadOptimizer, A::CSRMatr
     # quadind
     append!(instance.l_rows,addedrows)
 
-    rowvec, colvec, coefvec = A.row_pointers, A.columns, A.coefficients
+    rowvec, colvec, coefvec = row_pointers(A), colvals(A), row_nonzeros(A)
 
     rows = length(rhsvec)
     cols = size(instance.inner.A)[2]
-    push!(rowvec,length(colvec)+1)
 
     An = Array(SparseMatrixCSC(cols,rows,rowvec,colvec,coefvec)')
 
@@ -430,13 +429,10 @@ function LQOI.add_ranged_constraints!(instance::MockLinQuadOptimizer, A::CSRMatr
     # quadind
     append!(instance.l_rows,addedrows)
 
-    rowvec, colvec, coefvec = A.row_pointers, A.columns, A.coefficients
+    rowvec, colvec, coefvec = row_pointers(A), colvals(A), row_nonzeros(A)
     rows = length(lowerbound)
     cols = size(instance.inner.A)[2]
-    push!(rowvec,length(colvec)+1)
 
-    # An = Array(sparse(rowvec,colvec,coefvec,rows,cols))
-    # @show cols,rows,rowvec,colvec,coefvec
     An = Array(SparseMatrixCSC(cols,rows,rowvec,colvec,coefvec)')
 
     instance.inner.A = vcat(instance.inner.A,An)


### PR DESCRIPTION
This is a continuation of #96.    Which got accidentally closed.
The gist of this is that it changes CSRMatrix to be an alias for Transpose{SparseMatrixCSC}